### PR TITLE
hashi_vault - internal changes for env var processing and unwanted token loading fix

### DIFF
--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -334,6 +334,10 @@ class HashiVault:
             client_args['token'] = self.options.get('token')
 
         self.client = hvac.Client(**client_args)
+        # logout to prevent accidental use of inferred tokens
+        # https://github.com/ansible-collections/community.hashi_vault/issues/13
+        if 'token' not in client_args:
+            self.client.logout()
 
         # Check for old version, before auth_methods class (added in 0.7.0):
         # https://github.com/hvac/hvac/releases/tag/v0.7.0


### PR DESCRIPTION
##### SUMMARY
Most of this PR sets the stage for addressing the issues related to #10 and tracked in https://github.com/ansible-collections/community.hashi_vault/projects/1 .

Most of those will be addressable now by adding new entries to the `LOW_PRECEDENCE_ENV_VAR_OPTIONS` var if they need such a thing (the rest are just argspec `env:` replacements).

The change here sets that up, and moves that functionality for `token_path`'s `$HOME` env var into that (as it's the only option already using such a thing). As such it doesn't change the functionality or user interface, just the implementation.

This PR also fixes #13 by forcing the hvac client to logout when not doing token auth. 
This also doesn't change any current functionality, it just helps prevent auth methods from inadvertently not assigning their token to the client (previously that could have been masked by an accidentally inferred token, which is a problem in regular environments as well as in our CI).

Couple of minor comment/doc updates thrown in too.

No changelog since there are no observable changes for users.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hashi_vault.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
