### PR TITLE
hashi_vault - add support for using mount_point with aws_iam_login auth

### DIFF
--- a/changelogs/fragments/22-hashi_vault-aws_iam_login-mount_point.yml
+++ b/changelogs/fragments/22-hashi_vault-aws_iam_login-mount_point.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - hashi_vault - ``mount_point`` parameter did not work with ``aws_iam_login`` auth method (https://github.com/ansible-collections/community.hashi_vault/issues/7)

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -459,7 +459,7 @@ class HashiVault:
         self.client.auth_approle(**params)
 
     def auth_aws_iam_login(self):
-        params = self.options['iam_login_credentials']
+        params = self.options['_auth_aws_iam_login_params']
         if self.hvac_has_auth_methods and hasattr(self.client.auth.aws, 'iam_login'):
             self.client.auth.aws.iam_login(**params)
         else:
@@ -644,8 +644,11 @@ class LookupModule(LookupBase):
     def validate_auth_aws_iam_login(self, auth_method):
         params = {
             'access_key': self.get_option('aws_access_key'),
-            'secret_key': self.get_option('aws_secret_key')
+            'secret_key': self.get_option('aws_secret_key'),
         }
+
+        if self.get_option('mount_point'):
+            params['mount_point'] = self.get_option('mount_point')
 
         if self.get_option('role_id'):
             params['role'] = self.get_option('role_id')
@@ -677,7 +680,7 @@ class LookupModule(LookupBase):
             if session_credentials.token:
                 params['session_token'] = session_credentials.token
 
-        self.set_option('iam_login_credentials', params)
+        self.set_option('_auth_aws_iam_login_params', params)
 
     def validate_auth_jwt(self, auth_method):
         self.validate_by_required_fields(auth_method, 'role_id', 'jwt')

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -179,6 +179,7 @@ DOCUMENTATION = """
         - section: lookup_hashi_vault
           key: aws_iam_server_id
       required: False
+      version_added: '0.2.0'
 """
 
 EXAMPLES = """


### PR DESCRIPTION
##### SUMMARY
Fixes #7  

- Allows use of `mount_point` with `aws_iam_auth`

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hashi_vault.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
