### PR TITLE
hashi_vault - enable use of tokens without lookup-self

### DIFF
--- a/changelogs/fragments/23-hashi_vault-token_validation.yml
+++ b/changelogs/fragments/23-hashi_vault-token_validation.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - hashi_vault - tokens without ``lookup-self`` ability can't be used because of validation (https://github.com/ansible-collections/community.hashi_vault/issues/18).
+minor_changes:
+  - hashi_vault - add ``token_validate`` option to control token validation (https://github.com/ansible-collections/community.hashi_vault/pull/23).

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -63,7 +63,8 @@ DOCUMENTATION = """
         - section: lookup_hashi_vault
           key: token_validate
       type: boolean
-      default: True
+      default: true
+      version_added: 0.2.0
     url:
       description: URL to the Vault service.
       env:

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -279,7 +279,7 @@ EXAMPLES = """
 # However you can choose to create tokens without applying the default policy, or you can modify your default policy not to include it.
 # When disabled, your invalid or expired token will be indistinguishable from insufficent permissions.
 
-- name: authenticate with aws_iam_login
+- name: authenticate without token validation
   ansible.builtin.debug:
     msg: "{{ lookup('community.hashi_vault.hashi_vault', 'secret/hello:value', token=my_token, token_validate=False) }}"
 """

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -53,6 +53,17 @@ DOCUMENTATION = """
         - section: lookup_hashi_vault
           key: token_file
       default: '.vault-token'
+    token_validate:
+      description:
+        - For token auth, will perform a C(lookup-self) operation to determine the token's validity before using it.
+        - Disable if your token doesn't have the C(lookup-self) capability.
+      env:
+        - name: ANSIBLE_HASHI_VAULT_TOKEN_VALIDATE
+      ini:
+        - section: lookup_hashi_vault
+          key: token_validate
+      type: boolean
+      default: True
     url:
       description: URL to the Vault service.
       env:
@@ -262,6 +273,15 @@ EXAMPLES = """
 - name: Authenticate with a JWT
   ansible.builtin.debug:
     msg: "{{ lookup('community.hashi_vault.hashi_vault', 'secret/hola:val', auth_method='jwt', role_id='myroleid', jwt='myjwt', url='https://vault:8200') }}"
+
+# Disabling Token Validation
+# Use this when your token does not have the lookup-self capability. Usually this is applied to all tokens via the default policy.
+# However you can choose to create tokens without applying the default policy, or you can modify your default policy not to include it.
+# When disabled, your invalid or expired token will be indistinguishable from insufficent permissions.
+
+- name: authenticate with aws_iam_login
+  ansible.builtin.debug:
+    msg: "{{ lookup('community.hashi_vault.hashi_vault', 'secret/hello:value', token=my_token, token_validate=False) }}"
 """
 
 RETURN = """
@@ -434,7 +454,7 @@ class HashiVault:
     # 3. Update the avail_auth_methods list in the LookupModule's auth_methods() method (for now this is static).
     #
     def auth_token(self):
-        if not self.client.is_authenticated():
+        if self.options.get('token_validate') and not self.client.is_authenticated():
             raise AnsibleError("Invalid Hashicorp Vault Token Specified for hashi_vault lookup.")
 
     def auth_userpass(self):

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_setup.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_setup.yml
@@ -1,3 +1,7 @@
 - name: 'Create a test credentials (token)'
   command: '{{ vault_cmd }} token create -policy test-policy -field token'
   register: user_token_cmd
+
+- name: 'Create a test credentials (token)'
+  command: '{{ vault_cmd }} token create -policy test-policy -field token -no-default-policy'
+  register: user_token_no_default_policy_cmd

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_test.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_test.yml
@@ -1,4 +1,19 @@
-- vars:
+- name: "Test token with no default policy (missing lookup-self)"
+  vars:
+    user_token: '{{ user_token_no_default_policy_cmd.stdout }}'
+    lookup_terms: "{{ conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret1 auth_method=token token=' ~ user_token }}"
+  block:
+    - name: "Fetch a secret with no default policy token (failure expected)"
+      debug:
+        msg: "{{ lookup('community.hashi_vault.hashi_vault', lookup_terms) }}"
+      ignore_errors: yes
+
+    - name: "Fetch a secret with no default policy token - with no validation"
+      debug:
+        msg: "{{ lookup('community.hashi_vault.hashi_vault', lookup_terms ~ ' token_validate=false') }}"
+
+- name: "Normal token tests"
+  vars:
     user_token: '{{ user_token_cmd.stdout }}'
   block:
     - name: 'Fetch secrets using "hashi_vault" lookup'


### PR DESCRIPTION
##### SUMMARY
Fixes #18 

The issue has most of the technical information.

The method we use to determine if a token is valid relies on the token having the ability to lookup itself. By default, all tokens inherit the "default" policy in Vault, and by default the default policy contains that capability.

However when you create a token you may request that it doesn't include the default policy. You may also modify an installation's default policy to remove this capability.

In these cases, it would be impossible to use that (perfectly valid) token with this plugin, because it would fail early attempts to validate it.

This PR adds a new option allowing you to optionally disable that early validation.

When disabled, the token will be used to query a secret without any other checks. This means that if your token is expired or otherwise invalid, you will see the same error message as if your token wasn't granted the right permission.

- Adds a new boolean option `token_validate` to control whether a token should be validated
- Adds tests to ensure that a no-default-policy token fails with validation on and works with validation off
- Updated docs and examples

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hashi_vault.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
