### PR TITLE
hashi_vault - parameter env var changes for token and namespace

### DIFF
--- a/changelogs/fragments/25-non-breaking-env-parameter-changes.yml
+++ b/changelogs/fragments/25-non-breaking-env-parameter-changes.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - hashi_vault - ``namespace`` parameter can be specified in INI or via env vars ``ANSIBLE_HASHI_VAULT_NAMESPACE`` (new) and ``VAULT_NAMESPACE`` (lower preference)  (https://github.com/ansible-collections/community.hashi_vault/issues/14).
+  - hashi_vault - ``token`` parameter can now be specified via ``ANSIBLE_HASHI_VAULT_TOKEN`` as well as via ``VAULT_TOKEN`` (the latter with lower preference).

--- a/changelogs/fragments/25-non-breaking-env-parameter-changes.yml
+++ b/changelogs/fragments/25-non-breaking-env-parameter-changes.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
   - hashi_vault - ``namespace`` parameter can be specified in INI or via env vars ``ANSIBLE_HASHI_VAULT_NAMESPACE`` (new) and ``VAULT_NAMESPACE`` (lower preference)  (https://github.com/ansible-collections/community.hashi_vault/issues/14).
-  - hashi_vault - ``token`` parameter can now be specified via ``ANSIBLE_HASHI_VAULT_TOKEN`` as well as via ``VAULT_TOKEN`` (the latter with lower preference).
+  - hashi_vault - ``token`` parameter can now be specified via ``ANSIBLE_HASHI_VAULT_TOKEN`` as well as via ``VAULT_TOKEN`` (the latter with lower preference) (https://github.com/ansible-collections/community.hashi_vault/issues/16).

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -32,10 +32,12 @@ DOCUMENTATION = """
       required: True
     token:
       description:
-        - Vault token. If using token auth and no token is supplied, explicitly or through env, then the plugin will check
-        - for a token file, as determined by C(token_path) and C(token_file).
+        - Vault token. Token may be specified explicitly, through the listed env var, and also through the C(VAULT_TOKEN) env var.
+        - If no token is supplied, explicitly or through env, then the plugin will check for a token file, as determined by I(token_path) and I(token_file).
+        - The order of token loading (first found wins) is C(token param -> ANSIBLE_HASHI_VAULT_TOKEN -> VAULT_TOKEN -> token file).
       env:
-        - name: VAULT_TOKEN
+        - name: ANSIBLE_HASHI_VAULT_TOKEN
+          version_added: '0.2.0'
     token_path:
       description: If no token is specified, will try to read the token file from this path.
       env:
@@ -305,6 +307,7 @@ except ImportError:
 LOW_PRECEDENCE_ENV_VAR_OPTIONS = {
     'token_path': ['HOME'],
     'namespace': ['VAULT_NAMESPACE'],
+    'token': ['VAULT_TOKEN'],
 }
 
 

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -125,8 +125,14 @@ DOCUMENTATION = """
         - Vault namespace where secrets reside. This option requires HVAC 0.7.0+ and Vault 0.11+.
         - Optionally, this may be achieved by prefixing the authentication mount point and/or secret path with the namespace
           (e.g C(mynamespace/secret/mysecret)).
+        - If environment variable C(VAULT_NAMESPACE) is set, its value will be used last among all ways to specify I(namespace).
       env:
-        - name: VAULT_NAMESPACE
+        - name: ANSIBLE_HASHI_VAULT_NAMESPACE
+          version_added: '0.2.0'
+      ini:
+        - section: lookup_hashi_vault
+          key: namespace
+          version_added: '0.2.0'
     aws_profile:
       description: The AWS profile
       type: str
@@ -298,6 +304,7 @@ except ImportError:
 # value = list of env vars (in order of those checked first; process stops when value is found)
 LOW_PRECEDENCE_ENV_VAR_OPTIONS = {
     'token_path': ['HOME'],
+    'namespace': ['VAULT_NAMESPACE'],
 }
 
 


### PR DESCRIPTION
##### SUMMARY
Resolves #14 
- Add `ANSIBLE_HASHI_VAULT_NAMESPACE` env var to argspec
- Move `VAULT_NAMESPACE` env var to `LOW_PRECEDENCE_ENV_VAR_OPTIONS`
- Add new INI option for `namespace`

Resolves #16 
- Add `ANSIBLE_HASHI_VAULT_TOKEN` env var in argspec
- Move `VAULT_TOKEN` env var to `LOW_PRECEDENCE_ENV_VAR_OPTIONS`

These changes are non-breaking (see issues for detailed explanation).

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hashi_vault.py

##### ADDITIONAL INFORMATION
Overall project: https://github.com/ansible-collections/community.hashi_vault/projects/1
See also: #10 

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
