### PR TITLE
CI/Tests - Caching, multiple vault versions, etc.

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -23,10 +23,6 @@ jobs:
 # https://docs.ansible.com/ansible/latest/dev_guide/testing_sanity.html
 
   sanity:
-    env:
-      COLLECTION_PATH: ${{ needs.vars.outputs.collection_path }}
-      LOOKUP_HASHI_VAULT_PATH: ${{ needs.vars.outputs.lookup_hashi_vault_path }}
-      LOOKUP_HASHI_VAULT_BIN: ${{ needs.vars.outputs.lookup_hashi_vault_bin }}
     name: Sanity (Ⓐ${{ matrix.ansible }})
     strategy:
       matrix:
@@ -61,7 +57,7 @@ jobs:
       # and all python versions ansible supports.
       - name: Run sanity tests
         run: ansible-test sanity --docker -v --color
-        working-directory: ./ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
+        working-directory: ./ansible_collections/${{ env.NAMESPACE }}/${{ env.COLLECTION_NAME }}
 
 ###
 # Integration tests (RECOMMENDED)
@@ -101,9 +97,13 @@ jobs:
     steps:
       - name: Initialize env vars
         run: |
-          echo "COLLECTION_PATH=ansible_collections/${NAMESPACE}/${COLLECTION_NAME}" >> $GITHUB_ENV
-          echo "LOOKUP_HASHI_VAULT_PATH=${COLLECTION_PATH}/tests/integration/targets/lookup_hashi_vault" >> $GITHUB_ENV
-          echo "LOOKUP_HASHI_VAULT_BIN=${LOOKUP_HASHI_VAULT_PATH}/lookup_hashi_vault/files/bin" >> $GITHUB_ENV
+          COLLECTION_PATH=ansible_collections/${NAMESPACE}/${COLLECTION_NAME}
+          LOOKUP_HASHI_VAULT_PATH=${COLLECTION_PATH}/tests/integration/targets/lookup_hashi_vault
+          LOOKUP_HASHI_VAULT_BIN=${LOOKUP_HASHI_VAULT_PATH}/lookup_hashi_vault/files/bin
+
+          echo "COLLECTION_PATH=${COLLECTION_PATH}" >> $GITHUB_ENV
+          echo "LOOKUP_HASHI_VAULT_PATH=${LOOKUP_HASHI_VAULT_PATH}" >> $GITHUB_ENV
+          echo "LOOKUP_HASHI_VAULT_BIN=${LOOKUP_HASHI_VAULT_BIN}" >> $GITHUB_ENV
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -128,10 +128,10 @@ jobs:
         with:
           path: ${{ env.LOOKUP_HASHI_VAULT_BIN }}
           key: ${{ runner.os }}-vault${{ matrix.vault }}-${{ hashFiles(format('{0}/**', env.LOOKUP_HASHI_VAULT_BIN)) }} # future: include version/arch when configurable
-          # restore-keys: |
-          #   ${{ runner.os }}-vault${{ matrix.vault }}
 
-
+      # removing .gitignore lets the files in those dirs be sent to the container via ansible-test
+      # the files/bin dir will contain the vault binary downloaded a few steps later
+      # the vars/ dir will be used to write a file overriding role defaults (for Vault version)
       - name: Prepare for Vault version and caching
         run: |
           rm -f "${LOOKUP_HASHI_VAULT_BIN}/.gitignore"
@@ -144,10 +144,9 @@ jobs:
       - name: Install collection dependencies
         run: ansible-galaxy collection install community.crypto -p .
 
+      # this wil populate files/bin with the selected vault version binary
       - name: Pre-download Vault
-        # if: steps.cache.outputs.cache-hit != 'true'
-        # the "if" will be useful when our cache key is more specific
-        # the playbook already won't re-download if the file exists, it would just save a little time
+        if: steps.cache.outputs.cache-hit != 'true'
         env:
           ANSIBLE_ROLES_PATH: ../
         working-directory: ${{ env.LOOKUP_HASHI_VAULT_PATH }}/playbooks

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -27,7 +27,7 @@ jobs:
       - id: envs
         run: |
           COLLECTION_PATH=ansible_collections/${NAMESPACE}/${COLLECTION_NAME}
-          LOOKUP_HASHI_VAULT_PATH=${COLLECTION_PATH}/test/integration/targets/lookup_hashi_vault
+          LOOKUP_HASHI_VAULT_PATH=${COLLECTION_PATH}/tests/integration/targets/lookup_hashi_vault
           LOOKUP_HASHI_VAULT_BIN=${LOOKUP_HASHI_VAULT_PATH}/lookup_hashi_vault/files/bin
 
           echo "::set-output name=collection_path::${COLLECTION_PATH}"

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -14,6 +14,7 @@ on:
 env:
   NAMESPACE: community
   COLLECTION_NAME: hashi_vault
+  ANSIBLE_FORCE_COLOR: true
 
 jobs:
 

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -146,11 +146,12 @@ jobs:
 
       - name: Pre-download Vault
         # if: steps.cache.outputs.cache-hit != 'true'
-        # this will be useful when our cache key is more specific
+        # the "if" will be useful when our cache key is more specific
         # the playbook already won't re-download if the file exists, it would just save a little time
         env:
           ANSIBLE_ROLES_PATH: ../
-        run: ansible-playbook "${LOOKUP_HASHI_VAULT_PATH}/playbooks/download_vault.yml" -v
+        working-directory: ${{ env.LOOKUP_HASHI_VAULT_PATH }}/playbooks
+        run: ansible-playbook "download_vault.yml" -v
 
       # Run the integration tests
       - name: Run integration test

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -103,10 +103,10 @@ jobs:
           LOOKUP_HASHI_VAULT_BIN=${LOOKUP_HASHI_VAULT_PATH}/lookup_hashi_vault/files/bin
           LOOKUP_HASHI_VAULT_VARS=${LOOKUP_HASHI_VAULT_PATH}/lookup_hashi_vault/vars
 
-          echo "COLLECTION_PATH=${COLLECTION_PATH}" >> $GITHUB_ENV
-          echo "LOOKUP_HASHI_VAULT_PATH=${LOOKUP_HASHI_VAULT_PATH}" >> $GITHUB_ENV
-          echo "LOOKUP_HASHI_VAULT_BIN=${LOOKUP_HASHI_VAULT_BIN}" >> $GITHUB_ENV
-          echo "LOOKUP_HASHI_VAULT_VARS=${LOOKUP_HASHI_VAULT_VARS}" >> $GITHUB_ENV
+          echo "COLLECTION_PATH=${COLLECTION_PATH}" >> ${GITHUB_ENV}
+          echo "LOOKUP_HASHI_VAULT_PATH=${LOOKUP_HASHI_VAULT_PATH}" >> ${GITHUB_ENV}
+          echo "LOOKUP_HASHI_VAULT_BIN=${LOOKUP_HASHI_VAULT_BIN}" >> ${GITHUB_ENV}
+          echo "LOOKUP_HASHI_VAULT_VARS=${LOOKUP_HASHI_VAULT_VARS}" >> ${GITHUB_ENV}
 
       - name: Check out code
         uses: actions/checkout@v2
@@ -140,7 +140,7 @@ jobs:
       - name: Install collection dependencies
         run: ansible-galaxy collection install community.crypto -p .
 
-      # this wil populate files/bin with the selected vault version binary
+      # this will populate files/bin with the selected vault version binary
       - name: Pre-download Vault
         if: steps.cache.outputs.cache-hit != 'true'
         env:

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -71,10 +71,6 @@ jobs:
 # https://github.com/ansible-collections/community.zabbix/tree/master/.github/workflows
 
   integration:
-    env:
-      COLLECTION_PATH: ${{ needs.vars.outputs.collection_path }}
-      LOOKUP_HASHI_VAULT_PATH: ${{ needs.vars.outputs.lookup_hashi_vault_path }}
-      LOOKUP_HASHI_VAULT_BIN: ${{ needs.vars.outputs.lookup_hashi_vault_bin }}
     runs-on: ubuntu-latest
     name: I (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }} | Vault ${{ matrix.vault }})
     strategy:

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -14,6 +14,9 @@ on:
 env:
   NAMESPACE: community
   COLLECTION_NAME: hashi_vault
+  COLLECTION_PATH: ansible_collections/${{ env.NAMESPACE }}/${{ env.COLLECTION_NAME }}
+  LOOKUP_HASHI_VAULT_PATH: ${{ env.COLLECTION_PATH }}/test/integration/targets/lookup_hashi_vault
+  LOOKUP_HASHI_VAULT_BIN: ${{ env.LOOKUP_HASHI_VAULT_PATH }}/lookup_hashi_vault/files/bin
 
 jobs:
 
@@ -39,7 +42,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
         with:
-          path: ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
+          path: ${{ env.COLLECTION_PATH }}
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -89,15 +92,12 @@ jobs:
         exclude:
           - ansible: stable-2.9
             python: 3.9
-    env:
-      COLLECTION_PATH: ansible_collections/${{ env.NAMESPACE }}/${{ env.COLLECTION_NAME }}
-      LOOKUP_HASHI_VAULT_PATH: ${{ env.COLLECTION_PATH }}/test/integration/targets/lookup_hashi_vault
-      LOOKUP_HASHI_VAULT_BIN: ${{ env.LOOKUP_HASHI_VAULT_PATH }}/lookup_hashi_vault/files/bin
+
     steps:
       - name: Check out code
         uses: actions/checkout@v2
         with:
-          path: ${{ env.COLLECTIN_PATH }}
+          path: ${{ env.COLLECTION_PATH }}
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -91,6 +91,10 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
+        vault:
+          - 1.6.0
+          - 1.5.5
+          - 1.4.7
         exclude:
           - ansible: stable-2.9
             python: 3.9
@@ -101,10 +105,12 @@ jobs:
           COLLECTION_PATH=ansible_collections/${NAMESPACE}/${COLLECTION_NAME}
           LOOKUP_HASHI_VAULT_PATH=${COLLECTION_PATH}/tests/integration/targets/lookup_hashi_vault
           LOOKUP_HASHI_VAULT_BIN=${LOOKUP_HASHI_VAULT_PATH}/lookup_hashi_vault/files/bin
+          LOOKUP_HASHI_VAULT_VARS=${LOOKUP_HASHI_VAULT_PATH}/lookup_hashi_vault/vars
 
           echo "COLLECTION_PATH=${COLLECTION_PATH}" >> $GITHUB_ENV
           echo "LOOKUP_HASHI_VAULT_PATH=${LOOKUP_HASHI_VAULT_PATH}" >> $GITHUB_ENV
           echo "LOOKUP_HASHI_VAULT_BIN=${LOOKUP_HASHI_VAULT_BIN}" >> $GITHUB_ENV
+          echo "LOOKUP_HASHI_VAULT_VARS=${LOOKUP_HASHI_VAULT_VARS}" >> $GITHUB_ENV
 
       - name: Check out code
         uses: actions/checkout@v2
@@ -121,10 +127,13 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.LOOKUP_HASHI_VAULT_BIN }}
-          key: vault-${{ runner.os }} # future: include version/arch when configurable
+          key: vault-${{ runner.os }}-${{ matrix.vault }} # future: include version/arch when configurable
 
-      - name: Let ansible-test use the cache
-        run: rm -f "${LOOKUP_HASHI_VAULT_BIN}/.gitignore"
+      - name: Prepare for Vault version and caching
+        run: |
+          rm -f "${LOOKUP_HASHI_VAULT_BIN}/.gitignore"
+          rm -f "${LOOKUP_HASHI_VAULT_VARS}/.gitignore"
+          echo '{ "vault_version": "${{ matrix.vault }}" }' > "${LOOKUP_HASHI_VAULT_VARS}/main.json"
 
       - name: Install ansible-base (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -16,23 +16,6 @@ env:
   COLLECTION_NAME: hashi_vault
 
 jobs:
-  vars:
-    name: Build Env Vars
-    runs-on: ubuntu-latest
-    outputs:
-      collection_path: ${{ steps.envs.outputs.collection_path }}
-      lookup_hashi_vault_path: ${{ steps.envs.outputs.lookup_hashi_vault_path }}
-      lookup_hashi_vault_bin: ${{ steps.envs.outputs.lookup_hashi_vault_bin }}
-    steps:
-      - id: envs
-        run: |
-          COLLECTION_PATH=ansible_collections/${NAMESPACE}/${COLLECTION_NAME}
-          LOOKUP_HASHI_VAULT_PATH=${COLLECTION_PATH}/tests/integration/targets/lookup_hashi_vault
-          LOOKUP_HASHI_VAULT_BIN=${LOOKUP_HASHI_VAULT_PATH}/lookup_hashi_vault/files/bin
-
-          echo "::set-output name=collection_path::${COLLECTION_PATH}"
-          echo "::set-output name=lookup_hashi_vault_path::${LOOKUP_HASHI_VAULT_PATH}"
-          echo "::set-output name=lookup_hashi_vault_bin::${LOOKUP_HASHI_VAULT_BIN}"
 
 ###
 # Sanity tests (REQUIRED)
@@ -40,7 +23,6 @@ jobs:
 # https://docs.ansible.com/ansible/latest/dev_guide/testing_sanity.html
 
   sanity:
-    needs: vars
     env:
       COLLECTION_PATH: ${{ needs.vars.outputs.collection_path }}
       LOOKUP_HASHI_VAULT_PATH: ${{ needs.vars.outputs.lookup_hashi_vault_path }}
@@ -61,7 +43,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
         with:
-          path: ${{ env.COLLECTION_PATH }}
+          path: ansible_collections/${{ env.NAMESPACE }}/${{ env.COLLECTION_NAME }}
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -92,7 +74,6 @@ jobs:
 # https://github.com/ansible-collections/community.zabbix/tree/master/.github/workflows
 
   integration:
-    needs: vars
     env:
       COLLECTION_PATH: ${{ needs.vars.outputs.collection_path }}
       LOOKUP_HASHI_VAULT_PATH: ${{ needs.vars.outputs.lookup_hashi_vault_path }}
@@ -118,6 +99,12 @@ jobs:
             python: 3.9
 
     steps:
+      - name: Initialize env vars
+        run: |
+          echo "COLLECTION_PATH=ansible_collections/${NAMESPACE}/${COLLECTION_NAME}" >> $GITHUB_ENV
+          echo "LOOKUP_HASHI_VAULT_PATH=${COLLECTION_PATH}/tests/integration/targets/lookup_hashi_vault" >> $GITHUB_ENV
+          echo "LOOKUP_HASHI_VAULT_BIN=${LOOKUP_HASHI_VAULT_PATH}/lookup_hashi_vault/files/bin" >> $GITHUB_ENV
+
       - name: Check out code
         uses: actions/checkout@v2
         with:
@@ -156,12 +143,12 @@ jobs:
       # Run the integration tests
       - name: Run integration test
         run: ansible-test integration -v --color --retry-on-error --continue-on-error --diff --python ${{ matrix.python }} --docker --coverage
-        working-directory: ./ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
+        working-directory: ${{ env.COLLECTION_PATH }}
 
         # ansible-test support producing code coverage date
       - name: Generate coverage report
         run: ansible-test coverage xml -v --requirements --group-by command --group-by version
-        working-directory: ./ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
+        working-directory: ${{ env.COLLECTION_PATH }}
 
       # See the reports at https://codecov.io/gh/GITHUBORG/REPONAME
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -89,23 +89,44 @@ jobs:
         exclude:
           - ansible: stable-2.9
             python: 3.9
-
+    env:
+      COLLECTION_PATH: ansible_collections/${{ env.NAMESPACE }}/${{ env.COLLECTION_NAME }}
+      LOOKUP_HASHI_VAULT_PATH: ${{ env.COLLECTION_PATH }}/test/integration/targets/lookup_hashi_vault
+      LOOKUP_HASHI_VAULT_BIN: ${{ env.LOOKUP_HASHI_VAULT_PATH }}/lookup_hashi_vault/files/bin
     steps:
       - name: Check out code
         uses: actions/checkout@v2
         with:
-          path: ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
+          path: ${{ env.COLLECTIN_PATH }}
 
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
 
+      - name: Cache vault binaries
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.LOOKUP_HASHI_VAULT_BIN }}
+          key: vault-${{ runner.os }} # future: include version/arch when configurable
+
+      - name: Let ansible-test use the cache
+        run: rm -f "${LOOKUP_HASHI_VAULT_BIN}/.gitignore"
+
       - name: Install ansible-base (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
 
       - name: Install collection dependencies
         run: ansible-galaxy collection install community.crypto -p .
+
+      - name: Pre-download Vault
+        # if: steps.cache.outputs.cache-hit != 'true'
+        # this will be useful when our cache key is more specific
+        # the playbook already won't re-download if the file exists, it would just save a little time
+        env:
+          ANSIBLE_ROLES_PATH: ../
+        run: ansible-playbook "${LOOKUP_HASHI_VAULT_PATH}/playbooks/download_vault.yml" -v
 
       # Run the integration tests
       - name: Run integration test

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -14,11 +14,25 @@ on:
 env:
   NAMESPACE: community
   COLLECTION_NAME: hashi_vault
-  COLLECTION_PATH: ansible_collections/${{ env.NAMESPACE }}/${{ env.COLLECTION_NAME }}
-  LOOKUP_HASHI_VAULT_PATH: ${{ env.COLLECTION_PATH }}/test/integration/targets/lookup_hashi_vault
-  LOOKUP_HASHI_VAULT_BIN: ${{ env.LOOKUP_HASHI_VAULT_PATH }}/lookup_hashi_vault/files/bin
 
 jobs:
+  vars:
+    name: Build Env Vars
+    runs-on: ubuntu-latest
+    outputs:
+      collection_path: ${{ steps.envs.outputs.collection_path }}
+      lookup_hashi_vault_path: ${{ steps.envs.outputs.lookup_hashi_vault_path }}
+      lookup_hashi_vault_bin: ${{ steps.envs.outputs.lookup_hashi_vault_bin }}
+    steps:
+      - id: envs
+        run: |
+          COLLECTION_PATH=ansible_collections/${NAMESPACE}/${COLLECTION_NAME}
+          LOOKUP_HASHI_VAULT_PATH=${COLLECTION_PATH}/test/integration/targets/lookup_hashi_vault
+          LOOKUP_HASHI_VAULT_BIN=${LOOKUP_HASHI_VAULT_PATH}/lookup_hashi_vault/files/bin
+
+          echo "::set-output name=collection_path::${COLLECTION_PATH}"
+          echo "::set-output name=lookup_hashi_vault_path::${LOOKUP_HASHI_VAULT_PATH}"
+          echo "::set-output name=lookup_hashi_vault_bin::${LOOKUP_HASHI_VAULT_BIN}"
 
 ###
 # Sanity tests (REQUIRED)
@@ -26,6 +40,11 @@ jobs:
 # https://docs.ansible.com/ansible/latest/dev_guide/testing_sanity.html
 
   sanity:
+    needs: vars
+    env:
+      COLLECTION_PATH: ${{ needs.vars.outputs.collection_path }}
+      LOOKUP_HASHI_VAULT_PATH: ${{ needs.vars.outputs.lookup_hashi_vault_path }}
+      LOOKUP_HASHI_VAULT_BIN: ${{ needs.vars.outputs.lookup_hashi_vault_bin }}
     name: Sanity (Ⓐ${{ matrix.ansible }})
     strategy:
       matrix:
@@ -73,6 +92,11 @@ jobs:
 # https://github.com/ansible-collections/community.zabbix/tree/master/.github/workflows
 
   integration:
+    needs: vars
+    env:
+      COLLECTION_PATH: ${{ needs.vars.outputs.collection_path }}
+      LOOKUP_HASHI_VAULT_PATH: ${{ needs.vars.outputs.lookup_hashi_vault_path }}
+      LOOKUP_HASHI_VAULT_BIN: ${{ needs.vars.outputs.lookup_hashi_vault_bin }}
     runs-on: ubuntu-latest
     name: I (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }})
     strategy:

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -76,7 +76,7 @@ jobs:
       LOOKUP_HASHI_VAULT_PATH: ${{ needs.vars.outputs.lookup_hashi_vault_path }}
       LOOKUP_HASHI_VAULT_BIN: ${{ needs.vars.outputs.lookup_hashi_vault_bin }}
     runs-on: ubuntu-latest
-    name: I (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }})
+    name: I (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }} | Vault ${{ matrix.vault }})
     strategy:
       fail-fast: false
       matrix:
@@ -127,7 +127,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.LOOKUP_HASHI_VAULT_BIN }}
-          key: vault-${{ runner.os }}-${{ matrix.vault }} # future: include version/arch when configurable
+          key: ${{ runner.os }}-vault${{ matrix.vault }}-${{ hashFiles(format('{0}/**', env.LOOKUP_HASHI_VAULT_BIN)) }} # future: include version/arch when configurable
+          # restore-keys: |
+          #   ${{ runner.os }}-vault${{ matrix.vault }}
+
 
       - name: Prepare for Vault version and caching
         run: |

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/defaults/main.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/defaults/main.yml
@@ -13,7 +13,7 @@ vault_ansible_arch_table:
 
 vault_arch: "{{ vault_ansible_arch_table[ansible_architecture] }}"
 
-vault_version: '1.4.0'
+vault_version: '1.6.0'
 vault_bin: '{{ role_path }}/files/bin/{{ vault_slug }}'
 vault_slug: 'vault_{{ vault_version }}_{{ ansible_system | lower }}_{{ vault_arch }}'
 vault_zip: '{{ vault_bin }}/{{ vault_slug }}.zip'

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/defaults/main.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/defaults/main.yml
@@ -16,5 +16,6 @@ vault_arch: "{{ vault_ansible_arch_table[ansible_architecture] }}"
 vault_version: '1.4.0'
 vault_bin: '{{ role_path }}/files/bin/{{ vault_slug }}'
 vault_slug: 'vault_{{ vault_version }}_{{ ansible_system | lower }}_{{ vault_arch }}'
+vault_zip: '{{ vault_bin }}/{{ vault_slug }}.zip'
 vault_uri: 'https://releases.hashicorp.com/vault/{{ vault_version }}/{{ vault_slug }}.zip'
 vault_cmd: '{{ vault_bin }}/vault'

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/defaults/main.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/defaults/main.yml
@@ -3,3 +3,18 @@ vault_gen_path: 'gen/testproject'
 vault_kv1_path: 'kv1/testproject'
 vault_kv2_path: 'kv2/data/testproject'
 vault_kv2_multi_path: 'kv2/data/testmulti'
+
+## vars for vault server
+
+vault_ansible_arch_table:
+  'x86_64': 'amd64' # Linux
+  'amd64': 'amd64' # FreeBSD
+  'i386': '386'
+
+vault_arch: "{{ vault_ansible_arch_table[ansible_architecture] }}"
+
+vault_version: '1.4.0'
+vault_bin: '{{ role_path }}/files/bin/{{ vault_slug }}'
+vault_slug: 'vault_{{ vault_version }}_{{ ansible_system | lower }}_{{ vault_arch }}'
+vault_uri: 'https://releases.hashicorp.com/vault/{{ vault_version }}/{{ vault_slug }}.zip'
+vault_cmd: '{{ vault_bin }}/vault'

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/files/bin/.gitignore
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/files/bin/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/handlers/main.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/handlers/main.yml
@@ -1,0 +1,15 @@
+---
+# notify 'test_managed_vault_cleanup' for tasks related to the
+# vault server that is started by these tests
+# (those tasks should skip if the vault server is external to the test run)
+- name: 'Kill vault process'
+  shell: "kill $(cat {{ local_temp_dir }}/vault.pid)"
+  ignore_errors: true
+  listen: test_managed_vault_cleanup
+
+# notify 'cleanup' for any handlers that should always run at the end of tests
+- name: 'Delete temp dir'
+  file:
+    path: '{{ local_temp_dir }}'
+    state: absent
+  listen: cleanup

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/meta/main.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies: []
+#  - setup_remote_tmp_dir

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/meta/main.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/meta/main.yml
@@ -1,2 +1,0 @@
-dependencies: []
-#  - setup_remote_tmp_dir

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/main.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/main.yml
@@ -4,199 +4,32 @@
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 
-- name: Install Hashi Vault on controlled node and test
+- name: Create a local temporary directory
+  tempfile:
+    state: directory
+  register: tempfile_result
+  notify: cleanup
+
+- set_fact:
+    local_temp_dir: '{{ tempfile_result.path }}'
+
+- import_tasks: vault_server.yml
+
+- import_tasks: tests.yml
   vars:
-    vault_version: '0.11.0'
-    vault_uri: 'https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/lookup_hashi_vault/vault_{{ vault_version }}_{{ ansible_system | lower }}_{{ vault_arch }}.zip'
-    vault_cmd: '{{ local_temp_dir }}/vault'
-  block:
-    - name: Create a local temporary directory
-      tempfile:
-        state: directory
-      register: tempfile_result
+    auth_type: approle
+  when: ansible_distribution != 'RedHat' or ansible_distribution_major_version is version('7', '>')
 
-    - set_fact:
-        local_temp_dir: '{{ tempfile_result.path }}'
+- import_tasks: tests.yml
+  vars:
+    auth_type: approle_secret_id_less
+  when: ansible_distribution != 'RedHat' or ansible_distribution_major_version is version('7', '>')
 
-    - when: cryptography_version.stdout is version('1.6', '>=')
-      block:
-        - name: Generate privatekey
-          community.crypto.openssl_privatekey:
-            path: '{{ local_temp_dir }}/privatekey.pem'
+- import_tasks: tests.yml
+  vars:
+    auth_type: token
 
-        - name: Generate CSR
-          community.crypto.openssl_csr:
-            path: '{{ local_temp_dir }}/csr.csr'
-            privatekey_path: '{{ local_temp_dir }}/privatekey.pem'
-            subject:
-              commonName: localhost
-
-        - name: Generate selfsigned certificate
-          community.crypto.openssl_certificate:
-            path: '{{ local_temp_dir }}/cert.pem'
-            csr_path: '{{ local_temp_dir }}/csr.csr'
-            privatekey_path: '{{ local_temp_dir }}/privatekey.pem'
-            provider: selfsigned
-            selfsigned_digest: sha256
-          register: selfsigned_certificate
-
-    # NOTE: 'package' does not work properly with Ubuntu/Debian (like the 'default' docker image),
-    #       if you're running in a version of Python other than the "system" Python, due to system libraries
-    #       needed for the python 'apt' package. See https://stackoverflow.com/q/13708180/3905079
-    #       So for those OSes, we'll set the Python interpreter to the symlink in /usr/bin which should
-    #       always be the correct one that corresponds to the system libraries.
-    #
-    #       All this just for unzip, which is only needed to unzip the vault binary to set up for testing.
-    #       TODO: revisit how we set up vault in the first place or how we host the binary (.gz?)
-    - name: 'Install unzip'
-      vars:
-        # by assuming python3 here we're probably condeming this to not work on older Ubuntu/Debian (from like 2014?)
-        # but the alternative is probably reimplementing parts of interpreter_discovery.py
-        ansible_python_interpreter: "{{
-          '/usr/bin/python3' if ansible_distribution in ['Ubuntu', 'Debian'] else ansible_python.executable
-        }}"
-      package:
-        name: unzip
-      when: ansible_distribution != "MacOSX"  # unzip already installed (#TODO: get MacOSX tests working again)
-
-    - assert:
-        # Linux: x86_64, FreeBSD: amd64
-        that: ansible_architecture in ['i386', 'x86_64', 'amd64']
-    - set_fact:
-        vault_arch: '386'
-      when: ansible_architecture == 'i386'
-    - set_fact:
-        vault_arch: amd64
-      when: ansible_architecture in ['x86_64', 'amd64']
-
-    - name: 'Download vault binary'
-      unarchive:
-        src: '{{ vault_uri }}'
-        dest: '{{ local_temp_dir }}'
-        remote_src: true
-
-    - environment:
-        # used by vault command
-        VAULT_DEV_ROOT_TOKEN_ID: '47542cbc-6bf8-4fba-8eda-02e0a0d29a0a'
-      block:
-        - name: 'Create configuration file'
-          template:
-            src: vault_config.hcl.j2
-            dest: '{{ local_temp_dir }}/vault_config.hcl'
-
-        - name: 'Start vault service'
-          environment:
-            VAULT_ADDR: 'http://localhost:8200'
-          block:
-            - name: 'Start vault server (dev mode enabled)'
-              shell: 'nohup {{ vault_cmd }} server -dev -config {{ local_temp_dir }}/vault_config.hcl </dev/null >/dev/null 2>&1 &'
-
-            - name: 'Create generic secrets engine'
-              command: '{{ vault_cmd }} secrets enable -path=gen generic'
-
-            - name: 'Create KV v1 secrets engine'
-              command: '{{ vault_cmd }} secrets enable -path=kv1 -version=1 kv'
-
-            - name: 'Create KV v2 secrets engine'
-              command: '{{ vault_cmd }} secrets enable -path=kv2 -version=2 kv'
-
-            - name: 'Create a test policy'
-              command:
-                cmd: '{{ vault_cmd }} policy write test-policy -'
-                stdin: |
-                  path "{{ vault_gen_path }}/secret1" {
-                    capabilities = ["read"]
-                  }
-                  path "{{ vault_gen_path }}/secret2" {
-                    capabilities = ["read", "update"]
-                  }
-                  path "{{ vault_gen_path }}/secret3" {
-                    capabilities = ["deny"]
-                  }
-                  path "{{ vault_kv1_path }}/secret1" {
-                    capabilities = ["read"]
-                  }
-                  path "{{ vault_kv1_path }}/secret2" {
-                    capabilities = ["read", "update"]
-                  }
-                  path "{{ vault_kv1_path }}/secret3" {
-                    capabilities = ["deny"]
-                  }
-                  path "{{ vault_kv2_path }}/secret1" {
-                    capabilities = ["read"]
-                  }
-                  path "{{ vault_kv2_path }}/secret2" {
-                    capabilities = ["read", "update"]
-                  }
-                  path "{{ vault_kv2_path }}/secret3" {
-                    capabilities = ["deny"]
-                  }
-                  path "{{ vault_kv2_multi_path }}/secrets" {
-                    capabilities = ["read"]
-                  }
-                  path "{{ vault_kv2_path }}/secret4" {
-                    capabilities = ["read", "update"]
-                  }
-
-            - name: 'Create generic secrets'
-              command: '{{ vault_cmd }} write {{ vault_gen_path }}/secret{{ item }} value=foo{{ item }}'
-              loop: [1, 2, 3]
-
-            - name: 'Create KV v1 secrets'
-              command: '{{ vault_cmd }} kv put {{ vault_kv1_path }}/secret{{ item }} value=foo{{ item }}'
-              loop: [1, 2, 3]
-
-            - name: 'Create KV v2 secrets'
-              command: '{{ vault_cmd }} kv put {{ vault_kv2_path | regex_replace("/data") }}/secret{{ item }} value=foo{{ item }}'
-              loop: [1, 2, 3, 4]
-
-            - name: 'Update KV v2 secret4 with new value to create version'
-              command: '{{ vault_cmd }} kv put {{ vault_kv2_path | regex_replace("/data") }}/secret4 value=foo5'
-
-            - name: 'Create multiple KV v2 secrets under one path'
-              command: '{{ vault_cmd }} kv put {{ vault_kv2_multi_path | regex_replace("/data") }}/secrets value1=foo1 value2=foo2 value3=foo3'
-
-            - name: setup approle auth
-              import_tasks: approle_setup.yml
-              when: ansible_distribution != 'RedHat' or ansible_distribution_major_version is version('7', '>')
-
-            - name: setup approle secret_id_less auth
-              import_tasks: approle_secret_id_less_setup.yml
-              when: ansible_distribution != 'RedHat' or ansible_distribution_major_version is version('7', '>')
-
-            - name: setup token auth
-              import_tasks: token_setup.yml
-
-            - name: setup jwt auth
-              import_tasks: jwt_setup.yml
-              when: ansible_distribution != 'RedHat' or ansible_distribution_major_version is version('7', '>')
-
-        - import_tasks: tests.yml
-          vars:
-            auth_type: approle
-          when: ansible_distribution != 'RedHat' or ansible_distribution_major_version is version('7', '>')
-
-        - import_tasks: tests.yml
-          vars:
-            auth_type: approle_secret_id_less
-          when: ansible_distribution != 'RedHat' or ansible_distribution_major_version is version('7', '>')
-
-        - import_tasks: tests.yml
-          vars:
-            auth_type: token
-
-        - import_tasks: tests.yml
-          vars:
-            auth_type: jwt
-          when: ansible_distribution != 'RedHat' or ansible_distribution_major_version is version('7', '>')
-
-      always:
-        - name: 'Kill vault process'
-          shell: "kill $(cat {{ local_temp_dir }}/vault.pid)"
-          ignore_errors: true
-
-  always:
-    - name: 'Delete temp dir'
-      file:
-        path: '{{ local_temp_dir }}'
-        state: absent
+- import_tasks: tests.yml
+  vars:
+    auth_type: jwt
+  when: ansible_distribution != 'RedHat' or ansible_distribution_major_version is version('7', '>')

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/vault_download.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/vault_download.yml
@@ -1,0 +1,34 @@
+---
+# NOTE: 'package' does not work properly with Ubuntu/Debian (like the 'default' docker image),
+#       if you're running in a version of Python other than the "system" Python, due to system libraries
+#       needed for the python 'apt' package. See https://stackoverflow.com/q/13708180/3905079
+#       So for those OSes, we'll set the Python interpreter to the symlink in /usr/bin which should
+#       always be the correct one that corresponds to the system libraries.
+#
+#       All this just for unzip, which is only needed to unzip the vault binary to set up for testing.
+#       TODO: revisit how we set up vault in the first place or how we host the binary (.gz?)
+- name: 'Install unzip'
+  vars:
+    # by assuming python3 here we're probably condeming this to not work on older Ubuntu/Debian (from like 2014?)
+    # but the alternative is probably reimplementing parts of interpreter_discovery.py
+    ansible_python_interpreter: "{{
+      '/usr/bin/python3' if ansible_distribution in ['Ubuntu', 'Debian'] else ansible_python.executable
+    }}"
+  package:
+    name: unzip
+  when: ansible_distribution != "MacOSX"  # unzip already installed (#TODO: get MacOSX tests working again)
+
+- name: "Create bin directory"
+  file:
+    path: '{{ vault_bin }}'
+    state: directory
+
+- name: 'Download vault binary'
+  get_url:
+    url: '{{ vault_uri }}'
+    dest: '{{ vault_bin }}'
+
+- name: 'Extract vault binary'
+  unarchive:
+    src: '{{ vault_bin }}/{{ vault_slug }}.zip'
+    dest: '{{ vault_bin }}'

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/vault_download.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/vault_download.yml
@@ -26,9 +26,11 @@
 - name: 'Download vault binary'
   get_url:
     url: '{{ vault_uri }}'
-    dest: '{{ vault_bin }}'
+    dest: '{{ vault_zip }}'
 
 - name: 'Extract vault binary'
   unarchive:
-    src: '{{ vault_bin }}/{{ vault_slug }}.zip'
+    src: '{{ vault_zip }}'
     dest: '{{ vault_bin }}'
+    remote_src: yes
+    creates: '{{ vault_cmd }}'

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/vault_server.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/vault_server.yml
@@ -1,12 +1,5 @@
 ---
 - name: Install Hashi Vault on controlled node and test
-  # vars:
-  #   vault_bin: '{{ role_path }}/files/bin/{{ vault_slug }}'
-  #   vault_slug: 'vault_{{ vault_version }}_{{ ansible_system | lower }}_{{ vault_arch }}'
-  #   #vault_version: '0.11.0'
-  #   vault_version: '1.6.0'
-  #   vault_uri: 'https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/lookup_hashi_vault/vault_{{ vault_version }}_{{ ansible_system | lower }}_{{ vault_arch }}.zip'
-  #   vault_cmd: '{{ vault_bin }}/vault'
   block:
 
     - when: cryptography_version.stdout is version('1.6', '>=')
@@ -31,16 +24,6 @@
             selfsigned_digest: sha256
           register: selfsigned_certificate
 
-    # - assert:
-    #     # Linux: x86_64, FreeBSD: amd64
-    #     that: ansible_architecture in ['i386', 'x86_64', 'amd64']
-    # - set_fact:
-    #     vault_arch: '386'
-    #   when: ansible_architecture == 'i386'
-    # - set_fact:
-    #     vault_arch: amd64
-    #   when: ansible_architecture in ['x86_64', 'amd64']
-
     - name: "Check if vault binary exists"
       stat:
         path: '{{ vault_cmd }}'
@@ -49,12 +32,6 @@
         get_checksum: no
         get_mime: no
       register: bin_status
-
-    # - debug:
-    #     var: bin_status
-
-    # - shell: |
-    #     ls -alh {{ role_path }}/files/bin
 
     - name: "Download vault if not local"
       when: not bin_status.stat.exists
@@ -156,15 +133,3 @@
             - name: setup jwt auth
               import_tasks: jwt_setup.yml
               when: ansible_distribution != 'RedHat' or ansible_distribution_major_version is version('7', '>')
-
-
-      # always:
-        # - name: 'Kill vault process'
-        #   shell: "kill $(cat {{ local_temp_dir }}/vault.pid)"
-        #   ignore_errors: true
-
-  # always:
-    # - name: 'Delete temp dir'
-    #   file:
-    #     path: '{{ local_temp_dir }}'
-    #     state: absent

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/vault_server.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/vault_server.yml
@@ -1,0 +1,204 @@
+---
+- name: Install Hashi Vault on controlled node and test
+  vars:
+    vault_bin: '{{ role_path }}/files/bin/{{ vault_slug }}'
+    vault_slug: 'vault_{{ vault_version }}_{{ ansible_system | lower }}_{{ vault_arch }}'
+    #vault_version: '0.11.0'
+    vault_version: '1.6.0'
+    vault_uri: 'https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/lookup_hashi_vault/vault_{{ vault_version }}_{{ ansible_system | lower }}_{{ vault_arch }}.zip'
+    vault_cmd: '{{ vault_bin }}/vault'
+  block:
+
+    - when: cryptography_version.stdout is version('1.6', '>=')
+      block:
+        - name: Generate privatekey
+          community.crypto.openssl_privatekey:
+            path: '{{ local_temp_dir }}/privatekey.pem'
+
+        - name: Generate CSR
+          community.crypto.openssl_csr:
+            path: '{{ local_temp_dir }}/csr.csr'
+            privatekey_path: '{{ local_temp_dir }}/privatekey.pem'
+            subject:
+              commonName: localhost
+
+        - name: Generate selfsigned certificate
+          community.crypto.openssl_certificate:
+            path: '{{ local_temp_dir }}/cert.pem'
+            csr_path: '{{ local_temp_dir }}/csr.csr'
+            privatekey_path: '{{ local_temp_dir }}/privatekey.pem'
+            provider: selfsigned
+            selfsigned_digest: sha256
+          register: selfsigned_certificate
+
+    - assert:
+        # Linux: x86_64, FreeBSD: amd64
+        that: ansible_architecture in ['i386', 'x86_64', 'amd64']
+    - set_fact:
+        vault_arch: '386'
+      when: ansible_architecture == 'i386'
+    - set_fact:
+        vault_arch: amd64
+      when: ansible_architecture in ['x86_64', 'amd64']
+
+    - name: "Check if vault binary exists"
+      stat:
+        path: '{{ vault_cmd }}'
+        follow: yes
+        get_attributes: no
+        get_checksum: no
+        get_mime: no
+      register: bin_status
+
+    - debug:
+        var: bin_status
+
+    - shell: |
+        ls -alh {{ role_path }}/files/bin
+
+    - name: "Download vault if not local"
+      when: not bin_status.stat.exists
+      block:
+        # NOTE: 'package' does not work properly with Ubuntu/Debian (like the 'default' docker image),
+        #       if you're running in a version of Python other than the "system" Python, due to system libraries
+        #       needed for the python 'apt' package. See https://stackoverflow.com/q/13708180/3905079
+        #       So for those OSes, we'll set the Python interpreter to the symlink in /usr/bin which should
+        #       always be the correct one that corresponds to the system libraries.
+        #
+        #       All this just for unzip, which is only needed to unzip the vault binary to set up for testing.
+        #       TODO: revisit how we set up vault in the first place or how we host the binary (.gz?)
+        - name: 'Install unzip'
+          vars:
+            # by assuming python3 here we're probably condeming this to not work on older Ubuntu/Debian (from like 2014?)
+            # but the alternative is probably reimplementing parts of interpreter_discovery.py
+            ansible_python_interpreter: "{{
+              '/usr/bin/python3' if ansible_distribution in ['Ubuntu', 'Debian'] else ansible_python.executable
+            }}"
+          package:
+            name: unzip
+          when: ansible_distribution != "MacOSX"  # unzip already installed (#TODO: get MacOSX tests working again)
+
+        - name: "Create bin directory"
+          file:
+            path: '{{ vault_bin }}'
+            state: directory
+
+        - name: 'Download vault binary'
+          get_url:
+            url: '{{ vault_uri }}'
+            dest: '{{ vault_bin }}'
+
+        - name: 'Extract vault binary'
+          unarchive:
+            src: '{{ vault_bin }}/{{ vault_slug }}.zip'
+            dest: '{{ vault_bin }}'
+            #remote_src: true
+
+    - environment:
+        # used by vault command
+        VAULT_DEV_ROOT_TOKEN_ID: '47542cbc-6bf8-4fba-8eda-02e0a0d29a0a'
+      block:
+        - name: 'Create configuration file'
+          template:
+            src: vault_config.hcl.j2
+            dest: '{{ local_temp_dir }}/vault_config.hcl'
+
+        - name: 'Start vault service'
+          environment:
+            VAULT_ADDR: 'http://localhost:8200'
+          block:
+            - name: 'Start vault server (dev mode enabled)'
+              shell: 'nohup {{ vault_cmd }} server -dev -config {{ local_temp_dir }}/vault_config.hcl </dev/null >/dev/null 2>&1 &'
+              notify: test_managed_vault_cleanup
+
+            - name: 'Create generic secrets engine'
+              command: '{{ vault_cmd }} secrets enable -path=gen generic'
+
+            - name: 'Create KV v1 secrets engine'
+              command: '{{ vault_cmd }} secrets enable -path=kv1 -version=1 kv'
+
+            - name: 'Create KV v2 secrets engine'
+              command: '{{ vault_cmd }} secrets enable -path=kv2 -version=2 kv'
+
+            - name: 'Create a test policy'
+              command:
+                cmd: '{{ vault_cmd }} policy write test-policy -'
+                stdin: |
+                  path "{{ vault_gen_path }}/secret1" {
+                    capabilities = ["read"]
+                  }
+                  path "{{ vault_gen_path }}/secret2" {
+                    capabilities = ["read", "update"]
+                  }
+                  path "{{ vault_gen_path }}/secret3" {
+                    capabilities = ["deny"]
+                  }
+                  path "{{ vault_kv1_path }}/secret1" {
+                    capabilities = ["read"]
+                  }
+                  path "{{ vault_kv1_path }}/secret2" {
+                    capabilities = ["read", "update"]
+                  }
+                  path "{{ vault_kv1_path }}/secret3" {
+                    capabilities = ["deny"]
+                  }
+                  path "{{ vault_kv2_path }}/secret1" {
+                    capabilities = ["read"]
+                  }
+                  path "{{ vault_kv2_path }}/secret2" {
+                    capabilities = ["read", "update"]
+                  }
+                  path "{{ vault_kv2_path }}/secret3" {
+                    capabilities = ["deny"]
+                  }
+                  path "{{ vault_kv2_multi_path }}/secrets" {
+                    capabilities = ["read"]
+                  }
+                  path "{{ vault_kv2_path }}/secret4" {
+                    capabilities = ["read", "update"]
+                  }
+
+            - name: 'Create generic secrets'
+              command: '{{ vault_cmd }} write {{ vault_gen_path }}/secret{{ item }} value=foo{{ item }}'
+              loop: [1, 2, 3]
+
+            - name: 'Create KV v1 secrets'
+              command: '{{ vault_cmd }} kv put {{ vault_kv1_path }}/secret{{ item }} value=foo{{ item }}'
+              loop: [1, 2, 3]
+
+            - name: 'Create KV v2 secrets'
+              command: '{{ vault_cmd }} kv put {{ vault_kv2_path | regex_replace("/data") }}/secret{{ item }} value=foo{{ item }}'
+              loop: [1, 2, 3, 4]
+
+            - name: 'Update KV v2 secret4 with new value to create version'
+              command: '{{ vault_cmd }} kv put {{ vault_kv2_path | regex_replace("/data") }}/secret4 value=foo5'
+
+            - name: 'Create multiple KV v2 secrets under one path'
+              command: '{{ vault_cmd }} kv put {{ vault_kv2_multi_path | regex_replace("/data") }}/secrets value1=foo1 value2=foo2 value3=foo3'
+
+            - name: setup approle auth
+              import_tasks: approle_setup.yml
+              when: ansible_distribution != 'RedHat' or ansible_distribution_major_version is version('7', '>')
+
+            - name: setup approle secret_id_less auth
+              import_tasks: approle_secret_id_less_setup.yml
+              when: ansible_distribution != 'RedHat' or ansible_distribution_major_version is version('7', '>')
+
+            - name: setup token auth
+              import_tasks: token_setup.yml
+
+            - name: setup jwt auth
+              import_tasks: jwt_setup.yml
+              when: ansible_distribution != 'RedHat' or ansible_distribution_major_version is version('7', '>')
+
+
+      # always:
+        # - name: 'Kill vault process'
+        #   shell: "kill $(cat {{ local_temp_dir }}/vault.pid)"
+        #   ignore_errors: true
+
+  # always:
+    # - name: 'Delete temp dir'
+    #   file:
+    #     path: '{{ local_temp_dir }}'
+    #     state: absent

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/vault_server.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/vault_server.yml
@@ -1,12 +1,12 @@
 ---
 - name: Install Hashi Vault on controlled node and test
-  vars:
-    vault_bin: '{{ role_path }}/files/bin/{{ vault_slug }}'
-    vault_slug: 'vault_{{ vault_version }}_{{ ansible_system | lower }}_{{ vault_arch }}'
-    #vault_version: '0.11.0'
-    vault_version: '1.6.0'
-    vault_uri: 'https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/lookup_hashi_vault/vault_{{ vault_version }}_{{ ansible_system | lower }}_{{ vault_arch }}.zip'
-    vault_cmd: '{{ vault_bin }}/vault'
+  # vars:
+  #   vault_bin: '{{ role_path }}/files/bin/{{ vault_slug }}'
+  #   vault_slug: 'vault_{{ vault_version }}_{{ ansible_system | lower }}_{{ vault_arch }}'
+  #   #vault_version: '0.11.0'
+  #   vault_version: '1.6.0'
+  #   vault_uri: 'https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/lookup_hashi_vault/vault_{{ vault_version }}_{{ ansible_system | lower }}_{{ vault_arch }}.zip'
+  #   vault_cmd: '{{ vault_bin }}/vault'
   block:
 
     - when: cryptography_version.stdout is version('1.6', '>=')
@@ -31,15 +31,15 @@
             selfsigned_digest: sha256
           register: selfsigned_certificate
 
-    - assert:
-        # Linux: x86_64, FreeBSD: amd64
-        that: ansible_architecture in ['i386', 'x86_64', 'amd64']
-    - set_fact:
-        vault_arch: '386'
-      when: ansible_architecture == 'i386'
-    - set_fact:
-        vault_arch: amd64
-      when: ansible_architecture in ['x86_64', 'amd64']
+    # - assert:
+    #     # Linux: x86_64, FreeBSD: amd64
+    #     that: ansible_architecture in ['i386', 'x86_64', 'amd64']
+    # - set_fact:
+    #     vault_arch: '386'
+    #   when: ansible_architecture == 'i386'
+    # - set_fact:
+    #     vault_arch: amd64
+    #   when: ansible_architecture in ['x86_64', 'amd64']
 
     - name: "Check if vault binary exists"
       stat:
@@ -50,49 +50,15 @@
         get_mime: no
       register: bin_status
 
-    - debug:
-        var: bin_status
+    # - debug:
+    #     var: bin_status
 
-    - shell: |
-        ls -alh {{ role_path }}/files/bin
+    # - shell: |
+    #     ls -alh {{ role_path }}/files/bin
 
     - name: "Download vault if not local"
       when: not bin_status.stat.exists
-      block:
-        # NOTE: 'package' does not work properly with Ubuntu/Debian (like the 'default' docker image),
-        #       if you're running in a version of Python other than the "system" Python, due to system libraries
-        #       needed for the python 'apt' package. See https://stackoverflow.com/q/13708180/3905079
-        #       So for those OSes, we'll set the Python interpreter to the symlink in /usr/bin which should
-        #       always be the correct one that corresponds to the system libraries.
-        #
-        #       All this just for unzip, which is only needed to unzip the vault binary to set up for testing.
-        #       TODO: revisit how we set up vault in the first place or how we host the binary (.gz?)
-        - name: 'Install unzip'
-          vars:
-            # by assuming python3 here we're probably condeming this to not work on older Ubuntu/Debian (from like 2014?)
-            # but the alternative is probably reimplementing parts of interpreter_discovery.py
-            ansible_python_interpreter: "{{
-              '/usr/bin/python3' if ansible_distribution in ['Ubuntu', 'Debian'] else ansible_python.executable
-            }}"
-          package:
-            name: unzip
-          when: ansible_distribution != "MacOSX"  # unzip already installed (#TODO: get MacOSX tests working again)
-
-        - name: "Create bin directory"
-          file:
-            path: '{{ vault_bin }}'
-            state: directory
-
-        - name: 'Download vault binary'
-          get_url:
-            url: '{{ vault_uri }}'
-            dest: '{{ vault_bin }}'
-
-        - name: 'Extract vault binary'
-          unarchive:
-            src: '{{ vault_bin }}/{{ vault_slug }}.zip'
-            dest: '{{ vault_bin }}'
-            #remote_src: true
+      import_tasks: vault_download.yml
 
     - environment:
         # used by vault command

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/vars/.gitignore
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/vars/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/tests/integration/targets/lookup_hashi_vault/playbooks/download_vault.yml
+++ b/tests/integration/targets/lookup_hashi_vault/playbooks/download_vault.yml
@@ -1,0 +1,9 @@
+---
+- hosts: localhost
+  force_handlers: yes
+  gather_facts: yes
+  gather_subset: '!min,!all,distribution'
+  tasks:
+    - import_role:
+        name: lookup_hashi_vault
+        tasks_from: vault_download

--- a/tests/integration/targets/lookup_hashi_vault/playbooks/test_lookup_hashi_vault.yml
+++ b/tests/integration/targets/lookup_hashi_vault/playbooks/test_lookup_hashi_vault.yml
@@ -1,4 +1,5 @@
 - hosts: localhost
+  force_handlers: yes
   tasks:
     - name: register cryptography version
       command: "{{ ansible_python.executable }} -c 'import cryptography; print(cryptography.__version__)'"


### PR DESCRIPTION
##### SUMMARY

**Tests**
- Reorganized the parts of tests dedicated to downloading Vault and starting a Vault server to be more discrete
- Vault download / extraction happens in the role's `files/bin` directory now (`.gitignored`), more on that later
- Download is skipped if the requested version of the binary already exists, saving the download and extraction steps
- Playbook added that calls just the Vault download portion of the role
- Vars related to vault version and location are moved to `defaults/` to better control overriding them and so that they are available to all role entry points
- Download Vault binaries directly from hashiCorp's releases server
- "Default" version of Vault to be tested against is now 1.6.0, the current latest release.

**CI**
- Some deduping of vars and paths by setting them in env vars in a job step (integration only)
- Add Vault version to Matrix
  - With vars changes above, we can write a `vars/main` that overrides the Vault version set in `defaults/main`, controlling the version for everything invoked in CI
  - With download changes above, we can call the vault download playbook in a separate step to download the vault binary before starting the integration test (this will also implicitly use the vault version we wrote)
- Using the `cache` action, we can tell GitHub to cache the contents of the `files/bin` directory, based on a key we build from the runner OS and the Vault version. if the key is found, the cached contents are loaded into the directory.
  - With a cache hit, we skip the pre-download job altogether (if we run it anyway, it still won't re-download or extract anything because the role is written that way)
- Because `.gitignore` files were deleted, `ansible-test` will send the downloaded/cache-restored contents
- The `ansible-test` run is otherwise oblivious to the caching, but the file will exist, and so it will not re-download or extract anything

---

The caching isn't going to save us _that_ much time overall, although I will say the longest part of the process seemed to be installing `unzip` into Ubuntu 😕and that's now skipped generally. However the caching should help smooth over any issues with hosted binaries, as in the vast majority of runs we will be pulling from cache.

Cache entries are evicted after not being accessed for 7 days. If things slow enough on the repo that  no tests get run in that long, we can either decide that's fine, or set a cron trigger in CI to every 6 days or so to keep the cache primed.

---

**Running Tests Locally**
Using `ansible-test` locally still works like before; devs don't have to do anything special. But there are some caveats:
- If using `--docker` (as I do, and generally recommend everyone do), you won't be able to pre-download the binary or override the version with the `vars/` folder, because of the contents being `.gitignored`.
- You can delete the ignore files locally, but then you'll have unwanted git changes to deal with, which is also not ideal, but it is doable.

In any case, local `ansible-test` is fully functional, just not quite as optimized unless you're ok with being careful about your git changes


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
