### PR TITLE
Add parameter to support X-Vault-AWS-IAM-Server-ID

### DIFF
--- a/changelogs/fragments/27-add-hashi_vault-header_value-param.yml
+++ b/changelogs/fragments/27-add-hashi_vault-header_value-param.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - parse optional iam_server_id parameter as the value for X-Vault-AWS-IAM-Server-ID header (https://github.com/ansible-collections/community.hashi_vault/pull/27).
+  - Add optional ``aws_iam_server_id`` parameter as the value for ``X-Vault-AWS-IAM-Server-ID`` header (https://github.com/ansible-collections/community.hashi_vault/pull/27).

--- a/changelogs/fragments/27-add-hashi_vault-header_value-param.yml
+++ b/changelogs/fragments/27-add-hashi_vault-header_value-param.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - parse optional iam_server_id parameter as the value for X-Vault-AWS-IAM-Server-ID header (https://github.com/ansible-collections/community.hashi_vault/pull/27).

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -163,13 +163,13 @@ DOCUMENTATION = """
       env:
         - name: EC2_REGION
         - name: AWS_REGION
-    iam_server_id:
-      description: If specificed, sets the value to use for the X-Vault-AWS-IAM-Server-ID header as part of GetCallerIdentity request.
+    aws_iam_server_id:
+      description: If specified, sets the value to use for the C(X-Vault-AWS-IAM-Server-ID) header as part of C(GetCallerIdentity) request.
       env:
-        - name: ANSIBLE_HASHI_VAULT_IAM_SERVER_ID
+        - name: ANSIBLE_HASHI_VAULT_AWS_IAM_SERVER_ID
       ini:
         - section: lookup_hashi_vault
-          key: iam_server_id
+          key: aws_iam_server_id
       required: False
 """
 
@@ -643,8 +643,8 @@ class LookupModule(LookupBase):
         if self.get_option('region'):
             params['region'] = self.get_option('region')
 
-        if self.get_option('iam_server_id'):
-            params['header_value'] = self.get_option('iam_server_id')
+        if self.get_option('aws_iam_server_id'):
+            params['header_value'] = self.get_option('aws_iam_server_id')
 
         if not (params['access_key'] and params['secret_key']):
             profile = self.get_option('aws_profile')

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -163,6 +163,14 @@ DOCUMENTATION = """
       env:
         - name: EC2_REGION
         - name: AWS_REGION
+    iam_server_id:
+      description: If specificed, sets the value to use for the X-Vault-AWS-IAM-Server-ID header as part of GetCallerIdentity request.
+      env:
+        - name: ANSIBLE_HASHI_VAULT_IAM_SERVER_ID
+      ini:
+        - section: lookup_hashi_vault
+          key: iam_server_id
+      required: False
 """
 
 EXAMPLES = """
@@ -634,6 +642,9 @@ class LookupModule(LookupBase):
 
         if self.get_option('region'):
             params['region'] = self.get_option('region')
+
+        if self.get_option('iam_server_id'):
+            params['header_value'] = self.get_option('iam_server_id')
 
         if not (params['access_key'] and params['secret_key']):
             profile = self.get_option('aws_profile')


### PR DESCRIPTION
##### SUMMARY

Add support for the optional parameter iam_server_id.  The value is used for the X-Vault-AWS-IAM-Server-ID header as part of GetCallerIdentity request.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

hashi_vault

##### ADDITIONAL INFORMATION

Without this feature the following would fail when the Hashi Vault policy requires the X-Vault-AWS-IAM-Server-ID header.

```
- name: Authenticate with a Vault app role
  ansible.builtin.debug:
    msg: "{{ lookup('community.hashi_vault.hashi_vault', 'secret=secret/data/test:hello auth_method=aws_iam_login role_id=ec2-instance url=https://vault-fqdn region=us-west-2') }}"
```

Including the parameter header_value will pass the value along to the HVAC library, which then sends it along as the header. This would return the secret.

```
- name: Authenticate with a Vault app role
  ansible.builtin.debug:
    msg: "{{ lookup('community.hashi_vault.hashi_vault', 'secret=secret/data/test:hello auth_method=aws_iam_login role_id=ec2-instance url=https://vault-fqdn region=us-west-2 iam_server_id=vault-fqdn') }}"
```