### PR TITLE
hashi_vault - add AppRole deprecation and fix invalid deprecation logic

### DIFF
--- a/changelogs/fragments/33-approle-deprecation.yml
+++ b/changelogs/fragments/33-approle-deprecation.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - hashi_vault - uses new AppRole method in hvac 0.10.6 with fallback to deprecated method with warning (https://github.com/ansible-collections/community.hashi_vault/pull/33).
+bugfixes:
+  - hashi_vault - fallback logic for handling deprecated style of auth in hvac was not implemented correctly (https://github.com/ansible-collections/community.hashi_vault/pull/33).


### PR DESCRIPTION
##### SUMMARY
Fixes #32 

This started out just being a PR to use the newer hvac auth method class for AppRole, and add our deprecation fallback logic.

But I discovered that logic (which I put in place) only actually works on the positive case (the new auth method is available) and actually fails otherwise, so it was never working as intended 🤦‍♂️.

Took this opportunity to fix that, and make it more pythonic using exception handling instead of `hasattr()`.

Tested with multiple versions of hvac locally to ensure it worked right (we don't [yet] test multiple hvac versions in CI).

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hashi_vault.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
