### PR TITLE
hashi_vault - environment variable deprecations (and one addition)

### DIFF
--- a/changelogs/fragments/35-env-var-deprecations.yml
+++ b/changelogs/fragments/35-env-var-deprecations.yml
@@ -1,0 +1,15 @@
+---
+deprecated_features:
+  - hashi_vault - ``VAULT_ADDR`` environment variable for option ``url`` will have its precedence lowered in 1.0.0; use ``ANSIBLE_HASHI_VAULT_ADDR`` to intentionally override a config value (https://github.com/ansible-collections/community.hashi_vault/issues/8).
+  - hashi_vault - ``VAULT_AUTH_METHOD`` environment variable for option ``auth_method`` will be removed in 2.0.0, use ``ANSIBLE_HASHI_VAULT_AUTH_METHOD`` instead (https://github.com/ansible-collections/community.hashi_vault/issues/17).
+  - hashi_vault - ``VAULT_TOKEN_PATH`` environment variable for option ``token_path`` will be removed in 2.0.0, use ``ANSIBLE_HASHI_VAULT_TOKEN_PATH`` instead (https://github.com/ansible-collections/community.hashi_vault/issues/15).
+  - hashi_vault - ``VAULT_TOKEN_FILE`` environment variable for option ``token_file`` will be removed in 2.0.0, use ``ANSIBLE_HASHI_VAULT_TOKEN_FILE`` instead (https://github.com/ansible-collections/community.hashi_vault/issues/15).
+  - hashi_vault - ``VAULT_ROLE_ID`` environment variable for option ``role_id`` will be removed in 2.0.0, use ``ANSIBLE_HASHI_VAULT_ROLE_ID`` instead (https://github.com/ansible-collections/community.hashi_vault/issues/20).
+  - hashi_vault - ``VAULT_SECRET_ID`` environment variable for option ``secret_id`` will be removed in 2.0.0, use ``ANSIBLE_HASHI_VAULT_SECRET_ID`` instead (https://github.com/ansible-collections/community.hashi_vault/issues/20).
+minor_changes:
+  - hashi_vault - ``ANSIBLE_HASHI_VAULT_ADDR`` environment variable added for option ``url`` (https://github.com/ansible-collections/community.hashi_vault/issues/8).
+  - hashi_vault - ``ANSIBLE_HASHI_VAULT_AUTH_METHOD`` environment variable added for option ``auth_method`` (https://github.com/ansible-collections/community.hashi_vault/issues/17).
+  - hashi_vault - ``ANSIBLE_HASHI_VAULT_TOKEN_PATH`` environment variable added for option ``token_path`` (https://github.com/ansible-collections/community.hashi_vault/issues/15).
+  - hashi_vault - ``ANSIBLE_HASHI_VAULT_TOKEN_FILE`` environment variable added for option ``token_file`` (https://github.com/ansible-collections/community.hashi_vault/issues/15).
+  - hashi_vault - ``ANSIBLE_HASHI_VAULT_ROLE_ID`` environment variable added for option ``role_id`` (https://github.com/ansible-collections/community.hashi_vault/issues/20).
+  - hashi_vault - ``ANSIBLE_HASHI_VAULT_SECRET_ID`` environment variable added for option ``secret_id`` (https://github.com/ansible-collections/community.hashi_vault/issues/20).

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -82,6 +82,13 @@ DOCUMENTATION = """
         - Authentication method to be used.
       env:
         - name: VAULT_AUTH_METHOD
+          deprecated:
+            why: standardizing environment variables
+            version: 2.0.0
+            collection_name: community.hashi_vault
+            plugin_name: hashi_vault
+            alternatives: ANSIBLE_HASHI_VAULT_AUTH_METHOD
+        - name: ANSIBLE_HASHI_VAULT_AUTH_METHOD
       ini:
         - section: lookup_hashi_vault
           key: auth_method

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -704,6 +704,8 @@ class LookupModule(LookupBase):
 
     def validate_auth_approle(self, auth_method):
         self.validate_by_required_fields(auth_method, 'role_id')
+        # https://github.com/ansible-collections/community.hashi_vault/issues/35
+        self.get_option('secret_id')
 
     def validate_auth_token(self, auth_method):
         if auth_method == 'token':

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -705,6 +705,8 @@ class LookupModule(LookupBase):
 
     def validate_auth_approle(self, auth_method):
         self.validate_by_required_fields(auth_method, 'role_id')
+
+        # This lone superfluous get_option() is intentional, see:
         # https://github.com/ansible-collections/community.hashi_vault/issues/35
         self.get_option('secret_id')
 

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -72,6 +72,7 @@ DOCUMENTATION = """
       description: URL to the Vault service.
       env:
         - name: VAULT_ADDR
+        - name: ANSIBLE_HASHI_VAULT_ADDR
       ini:
         - section: lookup_hashi_vault
           key: url

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -40,16 +40,30 @@ DOCUMENTATION = """
         - name: ANSIBLE_HASHI_VAULT_TOKEN
           version_added: '0.2.0'
     token_path:
-      description: If no token is specified, will try to read the token file from this path.
+      description: If no token is specified, will try to read the I(token_file) from this path.
       env:
         - name: VAULT_TOKEN_PATH
+          deprecated:
+            why: standardizing environment variables
+            version: 2.0.0
+            collection_name: community.hashi_vault
+            plugin_name: hashi_vault
+            alternatives: ANSIBLE_HASHI_VAULT_TOKEN_PATH
+        - name: ANSIBLE_HASHI_VAULT_TOKEN_PATH
       ini:
         - section: lookup_hashi_vault
           key: token_path
     token_file:
-      description: If no token is specified, will try to read the token from this file in C(token_path).
+      description: If no token is specified, will try to read the token from this file in I(token_path).
       env:
         - name: VAULT_TOKEN_FILE
+          deprecated:
+            why: standardizing environment variables
+            version: 2.0.0
+            collection_name: community.hashi_vault
+            plugin_name: hashi_vault
+            alternatives: ANSIBLE_HASHI_VAULT_TOKEN_FILE
+        - name: ANSIBLE_HASHI_VAULT_TOKEN_FILE
       ini:
         - section: lookup_hashi_vault
           key: token_file

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -84,6 +84,13 @@ DOCUMENTATION = """
       description: Vault Role ID. Used in approle and aws_iam_login auth methods.
       env:
         - name: VAULT_ROLE_ID
+          deprecated:
+            why: standardizing environment variables
+            version: 2.0.0
+            collection_name: community.hashi_vault
+            plugin_name: hashi_vault
+            alternatives: ANSIBLE_HASHI_VAULT_ROLE_ID
+        - name: ANSIBLE_HASHI_VAULT_ROLE_ID
       ini:
         - section: lookup_hashi_vault
           key: role_id
@@ -91,6 +98,13 @@ DOCUMENTATION = """
       description: Secret ID to be used for Vault AppRole authentication.
       env:
         - name: VAULT_SECRET_ID
+          deprecated:
+            why: standardizing environment variables
+            version: 2.0.0
+            collection_name: community.hashi_vault
+            plugin_name: hashi_vault
+            alternatives: ANSIBLE_HASHI_VAULT_SECRET_ID
+        - name: ANSIBLE_HASHI_VAULT_SECRET_ID
     auth_method:
       description:
         - Authentication method to be used.

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -47,9 +47,9 @@ DOCUMENTATION = """
             why: standardizing environment variables
             version: 2.0.0
             collection_name: community.hashi_vault
-            plugin_name: hashi_vault
             alternatives: ANSIBLE_HASHI_VAULT_TOKEN_PATH
         - name: ANSIBLE_HASHI_VAULT_TOKEN_PATH
+          version_added: '0.2.0'
       ini:
         - section: lookup_hashi_vault
           key: token_path
@@ -61,9 +61,9 @@ DOCUMENTATION = """
             why: standardizing environment variables
             version: 2.0.0
             collection_name: community.hashi_vault
-            plugin_name: hashi_vault
             alternatives: ANSIBLE_HASHI_VAULT_TOKEN_FILE
         - name: ANSIBLE_HASHI_VAULT_TOKEN_FILE
+          version_added: '0.2.0'
       ini:
         - section: lookup_hashi_vault
           key: token_file
@@ -73,6 +73,7 @@ DOCUMENTATION = """
       env:
         - name: VAULT_ADDR
         - name: ANSIBLE_HASHI_VAULT_ADDR
+          version_added: '0.2.0'
       ini:
         - section: lookup_hashi_vault
           key: url
@@ -89,9 +90,9 @@ DOCUMENTATION = """
             why: standardizing environment variables
             version: 2.0.0
             collection_name: community.hashi_vault
-            plugin_name: hashi_vault
             alternatives: ANSIBLE_HASHI_VAULT_ROLE_ID
         - name: ANSIBLE_HASHI_VAULT_ROLE_ID
+          version_added: '0.2.0'
       ini:
         - section: lookup_hashi_vault
           key: role_id
@@ -103,9 +104,9 @@ DOCUMENTATION = """
             why: standardizing environment variables
             version: 2.0.0
             collection_name: community.hashi_vault
-            plugin_name: hashi_vault
             alternatives: ANSIBLE_HASHI_VAULT_SECRET_ID
         - name: ANSIBLE_HASHI_VAULT_SECRET_ID
+          version_added: '0.2.0'
     auth_method:
       description:
         - Authentication method to be used.
@@ -115,9 +116,9 @@ DOCUMENTATION = """
             why: standardizing environment variables
             version: 2.0.0
             collection_name: community.hashi_vault
-            plugin_name: hashi_vault
             alternatives: ANSIBLE_HASHI_VAULT_AUTH_METHOD
         - name: ANSIBLE_HASHI_VAULT_AUTH_METHOD
+          version_added: '0.2.0'
       ini:
         - section: lookup_hashi_vault
           key: auth_method
@@ -365,18 +366,18 @@ LOW_PRECEDENCE_ENV_VAR_OPTIONS = {
 # Fix: https://github.com/ansible/ansible/pull/73058
 #
 # If #73058 or another fix is backported, this should be removed.
-def deprecate(plugin_name='hashi_vault'):
+def deprecate(collection_name='community.hashi_vault'):
 
     # nicked from cli/__init__.py
     # with slight customizations to help filter out relevant messages
-    # (must add `plugin_name:` to the `deprecation:` dict)
+    # (relying on the collection name since it's a valid attrib and we only have 1 plugin at this time)
 
     # warn about deprecated config options
 
     for deprecated in list(C.config.DEPRECATED):
         name = deprecated[0]
         why = deprecated[1]['why']
-        if deprecated[1].get('plugin_name') != plugin_name:
+        if deprecated[1].get('collection_name') != collection_name:
             continue
 
         if 'alternatives' in deprecated[1]:


### PR DESCRIPTION
##### SUMMARY
Related: #10 and [Environment Variable Standardization project](https://github.com/ansible-collections/community.hashi_vault/projects/1#card-51750924).

- Add workaround for deprecations not being shown in lookups (https://github.com/ansible/ansible/issues/73051)
- Deprecate `VAULT_AUTH_METHOD` in preparation for removal in `2.0.0` (replaced by `ANSIBLE_HASHI_VAULT_AUTH_METHOD`) (#17)
- Deprecate `VAULT_TOKEN_FILE` and `VAULT_TOKEN_PATH` for removal in `2.0.0` (replaced by `ANSIBLE_HASHI_VAULT_` prefixed vars) (#15) 
- Deprecate `VAULT_SECRET_ID` and `VAULT_ROLE_ID` for removal in `2.0.0` (replaced by `ANSIBLE_HASHI_VAULT_` prefixed vars) (#20)
- Add `ANSIBLE_HASHI_VAULT_ADDR` in preparation for `VAULT_ADDR` precedence change in `1.0.0` (#8)
- Add forced `get_option` call for `secret_id` param (#35)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hashi_vault.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Most of the linked issues describe breaking changes. This PR is the non-breaking portions of those changes (deprecations, additions), with breaking (removal, etc.) changes happening in a major release.
