### PR TITLE
Release/automation

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -32,11 +32,14 @@ jobs:
           import os
           import yaml
 
+          ver = '${{ github.event.inputs.version }}'
+          ver_anchor = str.replace(ver, '.', '-')
+
           with open('changelogs/changelog.yaml', 'r') as s:
               ri = yaml.safe_load(s)
 
-          summary = ri['releases']['${{ github.event.inputs.version }}']['changes']['release_summary']
-          reldate = ri['releases']['${{ github.event.inputs.version }}']['release_date']
+          summary = ri['releases'][ver]['changes']['release_summary']
+          reldate = ri['releases'][ver]['release_date']
 
           description = '''## Summary
           Released: %s
@@ -45,8 +48,8 @@ jobs:
 
           ---
 
-          View the [complete changelog](https://github.com/ansible-collections/community.hashi_vault/blob/main/CHANGELOG.rst) to see all changes.
-          ''' % (reldate, summary)
+          View the [complete changelog](https://github.com/ansible-collections/community.hashi_vault/blob/main/CHANGELOG.rst#v%s) to see all changes.
+          ''' % (reldate, summary, ver_anchor)
 
           with open(os.environ['GITHUB_ENV'], 'a') as e:
               e.write("RELEASE_DESCRIPTION<<EOF\n%s\nEOF" % description)

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -30,13 +30,13 @@ jobs:
         shell: python
         run: |
           import os
-          import pyyaml
+          import yaml
 
-          with open('changelogs/fragments/changelog.yml', 'r') as s:
+          with open('changelogs/changelog.yaml', 'r') as s:
               ri = yaml.safe_load(s)
 
-          summary = ri['${{ github.event.inputs.version }}']['changes']['summary']
-          reldate = ri['${{ github.event.inputs.version }}']['release_date']
+          summary = ri['releases']['${{ github.event.inputs.version }}']['changes']['release_summary']
+          reldate = ri['releases']['${{ github.event.inputs.version }}']['release_date']
 
           description = '''## Summary
           Released: %s
@@ -46,16 +46,12 @@ jobs:
           ---
 
           View the [complete changelog](https://github.com/ansible-collections/community.hashi_vault/blob/main/CHANGELOG.rst) to see all changes.
-          ''' % reldate, summary
+          ''' % (reldate, summary)
 
           with open(os.environ['GITHUB_ENV'], 'a') as e:
               e.write("RELEASE_DESCRIPTION<<EOF\n%s\nEOF" % description)
 
-      - name: Test
-        run: echo $RELEASE_DESCRIPTION
-
       - name: Create Release
-        if: 'false'
         id: create_release
         uses: actions/create-release@v1
         env:

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   release:
-    name: Create Release From Tag
+    name: Create GitHub Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -23,8 +23,8 @@ jobs:
       - name: Install PyYaml
         run: pip install pyyaml
 
-      - name: Validate version is published
-        run: curl --head -s -f -o /dev/null https://galaxy.ansible.com/download/community-hashi_vault-{{ github.event.inputs.version }}.tar.gz
+      - name: Validate version is published to Galaxy
+        run: curl --head -s -f -o /dev/null https://galaxy.ansible.com/download/community-hashi_vault-${{ github.event.inputs.version }}.tar.gz
 
       - name: Build release description
         shell: python
@@ -35,16 +35,18 @@ jobs:
           with open('changelogs/fragments/changelog.yml', 'r') as s:
               ri = yaml.safe_load(s)
 
-          summary = ri['{{ github.event.inputs.version }}']['changes']['summary']
+          summary = ri['${{ github.event.inputs.version }}']['changes']['summary']
+          reldate = ri['${{ github.event.inputs.version }}']['release_date']
 
           description = '''## Summary
+          Released: %s
 
           %s
 
           ---
 
           View the [complete changelog](https://github.com/ansible-collections/community.hashi_vault/blob/main/CHANGELOG.rst) to see all changes.
-          ''' % summary
+          ''' % reldate, summary
 
           with open(os.environ['GITHUB_ENV'], 'a') as e:
               e.write("RELEASE_DESCRIPTION<<EOF\n%s\nEOF" % description)


### PR DESCRIPTION
##### SUMMARY
Updates / fixes to release automation in #39 

This workflow does the following:
- Triggered only manually, with a required parameter `version` for the version you want to create a release for
- Checks Galaxy to ensure that version is actually published there (so we don't create a release before the Zuul process is successful)
- Parses `changelog.yaml` to pull out the release summary and release date to build a small description for the GH release
- Links to the full changelog file with anchor to the specific release

##### ISSUE TYPE
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
