### PR TITLE
hashi_vault - lower VAULT_ADDR precedence

### DIFF
--- a/changelogs/fragments/41-lower-url-env-precedence.yml
+++ b/changelogs/fragments/41-lower-url-env-precedence.yml
@@ -1,0 +1,3 @@
+---
+breaking_changes:
+  - hashi_vault - the ``VAULT_ADDR`` environment variable is now checked last for the ``url`` parameter. For details on which use cases are impacted, see (https://github.com/ansible-collections/community.hashi_vault/issues/8).

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -81,9 +81,10 @@ DOCUMENTATION = """
       default: true
       version_added: 0.2.0
     url:
-      description: URL to the Vault service.
+      description:
+        - URL to the Vault service.
+        - If not specified by any other means, the value of the C(VAULT_ADDR) environment variable will be used.
       env:
-        - name: VAULT_ADDR
         - name: ANSIBLE_HASHI_VAULT_ADDR
           version_added: '0.2.0'
       ini:
@@ -379,6 +380,7 @@ LOW_PRECEDENCE_ENV_VAR_OPTIONS = {
     'token_path': ['HOME'],
     'namespace': ['VAULT_NAMESPACE'],
     'token': ['VAULT_TOKEN'],
+    'url': ['VAULT_ADDR'],
 }
 
 


### PR DESCRIPTION
##### SUMMARY
Resolves #8 
See also #10 

With the addition of `ANSIBLE_HASHI_VAULT_ADDR` in #36 , `VAULT_ADDR` will now be used as a value of last resort, so that it does not inadvertently override an INI-specified `url` (which can still be overridden with the new env var).

This is a breaking change that is not expected to impact most users. See #8 for details on what scenarios will be impacted.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hashi_vault.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
