### PR TITLE
Fix incorrect link in 0.2.0 changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,7 @@ Minor Changes
 - hashi_vault - ``ANSIBLE_HASHI_VAULT_TOKEN_PATH`` environment variable added for option ``token_path`` (https://github.com/ansible-collections/community.hashi_vault/issues/15).
 - hashi_vault - ``namespace`` parameter can be specified in INI or via env vars ``ANSIBLE_HASHI_VAULT_NAMESPACE`` (new) and ``VAULT_NAMESPACE`` (lower preference)  (https://github.com/ansible-collections/community.hashi_vault/issues/14).
 - hashi_vault - ``token`` parameter can now be specified via ``ANSIBLE_HASHI_VAULT_TOKEN`` as well as via ``VAULT_TOKEN`` (the latter with lower preference) (https://github.com/ansible-collections/community.hashi_vault/issues/16).
-- hashi_vault - add ``token_validate`` option to control token validation (https://github.com/ansible-collections/community.hashi_vault/pull/23).
+- hashi_vault - add ``token_validate`` option to control token validation (https://github.com/ansible-collections/community.hashi_vault/pull/24).
 - hashi_vault - uses new AppRole method in hvac 0.10.6 with fallback to deprecated method with warning (https://github.com/ansible-collections/community.hashi_vault/pull/33).
 
 Deprecated Features
@@ -54,4 +54,3 @@ Release Summary
 ---------------
 
 Our first release matches the ``hashi_vault`` lookup functionality provided by ``community.general`` version ``1.3.0``.
-

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -53,7 +53,7 @@ releases:
         ``ANSIBLE_HASHI_VAULT_NAMESPACE`` (new) and ``VAULT_NAMESPACE`` (lower preference)  (https://github.com/ansible-collections/community.hashi_vault/issues/14).
       - hashi_vault - ``token`` parameter can now be specified via ``ANSIBLE_HASHI_VAULT_TOKEN``
         as well as via ``VAULT_TOKEN`` (the latter with lower preference) (https://github.com/ansible-collections/community.hashi_vault/issues/16).
-      - hashi_vault - add ``token_validate`` option to control token validation (https://github.com/ansible-collections/community.hashi_vault/pull/23).
+      - hashi_vault - add ``token_validate`` option to control token validation (https://github.com/ansible-collections/community.hashi_vault/pull/24).
       - hashi_vault - uses new AppRole method in hvac 0.10.6 with fallback to deprecated
         method with warning (https://github.com/ansible-collections/community.hashi_vault/pull/33).
       release_summary: 'Several backwards-compatible bugfixes and enhancements in
@@ -63,7 +63,7 @@ releases:
     fragments:
     - 0.2.0.yml
     - 22-hashi_vault-aws_iam_login-mount_point.yml
-    - 23-hashi_vault-token_validation.yml
+    - 24-hashi_vault-token_validation.yml
     - 25-non-breaking-env-parameter-changes.yml
     - 27-add-hashi_vault-header_value-param.yml
     - 31-jwt-mount_point.yml


### PR DESCRIPTION
##### SUMMARY
One of the changes points to a closed PR and not the actual PR.
Just updating the link in the changelog locations.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
