### PR TITLE
(internals) moving more functionality centrally, more tests

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
 ---
+ignore:
+  - "**/tests/unit/compat/*"
+
 fixes:
   - "ansible_collections/community/hashi_vault/::"

--- a/plugins/doc_fragments/connection.py
+++ b/plugins/doc_fragments/connection.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2012, Brian Scholer (@briantist)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+
+    DOCUMENTATION = r'''
+    options:
+      url:
+        description:
+          - URL to the Vault service.
+          - If not specified by any other means, the value of the C(VAULT_ADDR) environment variable will be used.
+          - If C(VAULT_ADDR) is also not defined then a default of C(http://127.0.0.1:8200) will be used.
+        env:
+          - name: ANSIBLE_HASHI_VAULT_ADDR
+            version_added: '0.2.0'
+        ini:
+          - section: lookup_hashi_vault
+            key: url
+      proxies:
+        description:
+          - URL(s) to the proxies used to access the Vault service.
+          - It can be a string or a dict.
+          - If it's a dict, provide the scheme (eg. C(http) or C(https)) as the key, and the URL as the value.
+          - If it's a string, provide a single URL that will be used as the proxy for both C(http) and C(https) schemes.
+          - A string that can be interpreted as a dictionary will be converted to one (see examples).
+          - You can specify a different proxy for HTTP and HTTPS resources.
+          - If not specified, L(environment variables from the Requests library,https://requests.readthedocs.io/en/master/user/advanced/#proxies) are used.
+        env:
+          - name: ANSIBLE_HASHI_VAULT_PROXIES
+        ini:
+          - section: lookup_hashi_vault
+            key: proxies
+        type: raw
+        version_added: '1.1.0'
+      ca_cert:
+        description: Path to certificate to use for authentication.
+        aliases: [ cacert ]
+      validate_certs:
+        description:
+          - Controls verification and validation of SSL certificates, mostly you only want to turn off with self signed ones.
+          - Will be populated with the inverse of C(VAULT_SKIP_VERIFY) if that is set and I(validate_certs) is not explicitly provided.
+          - Will default to C(true) if neither I(validate_certs) or C(VAULT_SKIP_VERIFY) are set.
+        type: boolean
+      namespace:
+        description:
+          - Vault namespace where secrets reside. This option requires HVAC 0.7.0+ and Vault 0.11+.
+          - Optionally, this may be achieved by prefixing the authentication mount point and/or secret path with the namespace
+            (e.g C(mynamespace/secret/mysecret)).
+          - If environment variable C(VAULT_NAMESPACE) is set, its value will be used last among all ways to specify I(namespace).
+        env:
+          - name: ANSIBLE_HASHI_VAULT_NAMESPACE
+            version_added: '0.2.0'
+        ini:
+          - section: lookup_hashi_vault
+            key: namespace
+            version_added: '0.2.0'
+    '''

--- a/plugins/lookup/__init__.py
+++ b/plugins/lookup/__init__.py
@@ -16,6 +16,10 @@ display = Display()
 
 class HashiVaultLookupBase(HashiVaultPlugin, LookupBase):
 
+    def __init__(self, loader=None, templar=None, **kwargs):
+        HashiVaultPlugin.__init__(self)
+        LookupBase.__init__(self, loader=loader, templar=templar, **kwargs)
+
     def parse_kev_term(self, term, plugin_name, first_unqualified=None):
         '''parses a term string into a dictionary'''
         param_dict = {}

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -382,9 +382,7 @@ _raw:
 import os
 
 from ansible.errors import AnsibleError
-from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.utils.display import Display
-from ansible.module_utils.common.validation import check_type_dict, check_type_str
 
 from ansible_collections.community.hashi_vault.plugins.lookup.__init__ import HashiVaultLookupBase
 from ansible_collections.community.hashi_vault.plugins.module_utils.hashi_vault_common import HashiVaultHelper

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -445,10 +445,6 @@ class HashiVault:
         if self.options.get('namespace'):
             client_args['namespace'] = self.options['namespace']
 
-        # this is the only auth_method-specific thing here, because if we're using a token, we need it now
-        if self.options['auth_method'] == 'token':
-            client_args['token'] = self.options.get('token')
-
         if self.options.get('proxies') is not None:
             client_args['proxies'] = self.options.get('proxies')
 
@@ -530,6 +526,9 @@ class HashiVault:
     #    0.10.6 -- approle
     #
     def auth_token(self):
+        if self.options['auth_method'] == 'token':
+            self.client.token = self.options.get('token')
+
         if self.options.get('token_validate') and not self.client.is_authenticated():
             raise AnsibleError("Invalid Hashicorp Vault Token Specified for hashi_vault lookup.")
 

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -27,6 +27,7 @@ DOCUMENTATION = """
     - As of community.hashi_vault 0.1.0, only the latest version of a secret is returned when specifying a KV v2 path.
     - As of community.hashi_vault 0.1.0, all options can be supplied via term string (space delimited key=value pairs) or by parameters (see examples).
     - As of community.hashi_vault 0.1.0, when I(secret) is the first option in the term string, C(secret=) is not required (see examples).
+  extends_documentation_fragment: community.hashi_vault.connection
   options:
     secret:
       description: Vault path to the secret being requested in the format C(path[:field]).
@@ -80,37 +81,10 @@ DOCUMENTATION = """
       type: boolean
       default: true
       version_added: 0.2.0
-    url:
-      description:
-        - URL to the Vault service.
-        - If not specified by any other means, the value of the C(VAULT_ADDR) environment variable will be used.
-        - If C(VAULT_ADDR) is also not defined then a default of C(http://127.0.0.1:8200) will be used.
-      env:
-        - name: ANSIBLE_HASHI_VAULT_ADDR
-          version_added: '0.2.0'
-      ini:
-        - section: lookup_hashi_vault
-          key: url
     username:
       description: Authentication user name.
     password:
       description: Authentication password.
-    proxies:
-      description:
-        - URL(s) to the proxies used to access the Vault service.
-        - It can be a string or a dict.
-        - If it's a dict, provide the scheme (eg. C(http) or C(https)) as the key, and the URL as the value.
-        - If it's a string, provide a single URL that will be used as the proxy for both C(http) and C(https) schemes.
-        - A string that can be interpreted as a dictionary will be converted to one (see examples).
-        - You can specify a different proxy for HTTP and HTTPS resources.
-        - If not specified, L(environment variables from the Requests library,https://requests.readthedocs.io/en/master/user/advanced/#proxies) are used.
-      env:
-        - name: ANSIBLE_HASHI_VAULT_PROXIES
-      ini:
-        - section: lookup_hashi_vault
-          key: proxies
-      type: raw
-      version_added: '1.1.0'
     role_id:
       description: Vault Role ID. Used in approle and aws_iam_login auth methods.
       env:
@@ -180,28 +154,6 @@ DOCUMENTATION = """
       description: The JSON Web Token (JWT) to use for JWT authentication to Vault.
       env:
         - name: ANSIBLE_HASHI_VAULT_JWT
-    ca_cert:
-      description: Path to certificate to use for authentication.
-      aliases: [ cacert ]
-    validate_certs:
-      description:
-        - Controls verification and validation of SSL certificates, mostly you only want to turn off with self signed ones.
-        - Will be populated with the inverse of C(VAULT_SKIP_VERIFY) if that is set and I(validate_certs) is not explicitly provided.
-        - Will default to C(true) if neither I(validate_certs) or C(VAULT_SKIP_VERIFY) are set.
-      type: boolean
-    namespace:
-      description:
-        - Vault namespace where secrets reside. This option requires HVAC 0.7.0+ and Vault 0.11+.
-        - Optionally, this may be achieved by prefixing the authentication mount point and/or secret path with the namespace
-          (e.g C(mynamespace/secret/mysecret)).
-        - If environment variable C(VAULT_NAMESPACE) is set, its value will be used last among all ways to specify I(namespace).
-      env:
-        - name: ANSIBLE_HASHI_VAULT_NAMESPACE
-          version_added: '0.2.0'
-      ini:
-        - section: lookup_hashi_vault
-          key: namespace
-          version_added: '0.2.0'
     aws_profile:
       description: The AWS profile
       type: str

--- a/plugins/module_utils/hashi_vault_common.py
+++ b/plugins/module_utils/hashi_vault_common.py
@@ -171,6 +171,17 @@ class HashiVaultOptionAdapter(object):
 class HashiVaultOptionGroupBase:
     '''A base class for class option group classes'''
 
+    # see https://github.com/ansible-collections/community.hashi_vault/issues/10
+    #
+    # Options which seek to use environment vars that are not Ansible-specific
+    # should load those as values of last resort, so that INI values can override them.
+    # For default processing, list such options and vars here.
+    # Alternatively, process them in another appropriate place like an auth method's
+    # validate_ method.
+    #
+    # key = option_name
+    # value = list of env vars (in order of those checked first; process stops when value is found)
+
     # for now copying here
     # going to re-think where to specify these
     _LOW_PRECEDENCE_ENV_VAR_OPTIONS = {

--- a/plugins/module_utils/hashi_vault_common.py
+++ b/plugins/module_utils/hashi_vault_common.py
@@ -90,7 +90,7 @@ class HashiVaultOptionAdapter(object):
             # AnsiblePlugin.has_option was added in 2.10, see https://github.com/ansible/ansible/pull/61078
         )
 
-    def __init__(self, getter, setter, haver=None, updater=None, getitems=None, getitemsdefault=None, defaultsetter=None, defaultgetter=None):
+    def __init__(self, getter, setter, haver=None, updater=None, getitems=None, defaultsetter=None, defaultgetter=None):
         def _default_default_setter(key, default=None):
             try:
                 value = self.get_option(key)
@@ -113,9 +113,6 @@ class HashiVaultOptionAdapter(object):
         def _default_getitems(*args):
             return dict((key, self.get_option(key)) for key in args)
 
-        def _default_getitems_default(default=None, *args):
-            return dict((key, self.get_option_default(key, default)) for key in args)
-
         def _default_default_getter(key, default):
             try:
                 return self.get_option(key)
@@ -128,7 +125,6 @@ class HashiVaultOptionAdapter(object):
         self._haver = haver or _default_haver
         self._updater = updater or _default_updater
         self._getitems = getitems or _default_getitems
-        self._getitemsdefault = getitemsdefault or _default_getitems_default
         self._defaultsetter = defaultsetter or _default_default_setter
         self._defaultgetter = defaultgetter or _default_default_getter
 
@@ -152,9 +148,6 @@ class HashiVaultOptionAdapter(object):
 
     def get_options(self, *args):
         return self._getitems(*args)
-
-    def get_options_default(self, default=None, *args):
-        return self._getitemsdefault(default, *args)
 
 
 class HashiVaultConnectionOptions:

--- a/plugins/module_utils/hashi_vault_common.py
+++ b/plugins/module_utils/hashi_vault_common.py
@@ -5,6 +5,10 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+import os
+
+from ansible.module_utils.common.validation import check_type_dict, check_type_str, check_type_bool
+
 HAS_HVAC = False
 try:
     import hvac
@@ -39,3 +43,161 @@ class HashiVaultHelper():
             client.logout(revoke_token=hashi_vault_revoke_on_logout)
 
         return client
+
+
+class HashiVaultOptionAdapter(object):
+    '''
+    The purpose of this class is to provide a standard interface for option getting/setting
+    within module_utils code, since the processes are so different in plugins and modules.
+
+    Attention is paid to ensuring that in plugins we use the methods provided by Config Manager,
+    but to allow flexibility to create an adapter to work with other sources, hence the design
+    of defining specific methods exposed, and having them call provided function references.
+    '''
+    # More context on the need to call Config Manager methods:
+    #
+    # Some issues raised around deprecations in plugins not being processed led to comments
+    # from core maintainers around the need to use Config Manager and also to ensure any
+    # option needed is always retrieved using AnsiblePlugin.get_option(). At the time of this
+    # writing, based on the way Config Manager is implemented, that's not actually necessary,
+    # and calling AnsiblePlugin.set_options() to initialize them is enough. But that's not
+    # guaranteed to stay that way, if get_option() is used to "trigger" internal events.
+    #
+    # More reading:
+    # - https://github.com/ansible-collections/community.hashi_vault/issues/35
+    # - https://github.com/ansible/ansible/issues/73051
+    # - https://github.com/ansible/ansible/pull/73058
+    # - https://github.com/ansible/ansible/pull/73239
+    # - https://github.com/ansible/ansible/pull/73240
+
+    @classmethod
+    def from_dict(cls, dict):
+        return cls(
+            getter=dict.__getitem__,
+            setter=dict.__setitem__,
+            haver=lambda key: key in dict,
+            updater=dict.update,
+            defaultsetter=dict.setdefault,
+            defaultgetter=dict.get,
+        )
+
+    @classmethod
+    def from_ansible_plugin(cls, plugin):
+        return cls(
+            getter=plugin.get_option,
+            setter=plugin.set_option,
+            haver=plugin.has_option if hasattr(plugin, 'has_option') else None,
+            # AnsiblePlugin.has_option was added in 2.10, see https://github.com/ansible/ansible/pull/61078
+        )
+
+    def __init__(self, getter, setter, haver=None, updater=None, getitems=None, getitemsdefault=None, defaultsetter=None, defaultgetter=None):
+        def _default_default_setter(key, default=None):
+            try:
+                value = self.get_option(key)
+                return value
+            except KeyError:
+                self.set_option(key, default)
+                return default
+
+        def _default_updater(**kwargs):
+            for key, value in kwargs.items():
+                self.set_option(key, value)
+
+        def _default_haver(key):
+            try:
+                self.get_option(key)
+                return True
+            except KeyError:
+                return False
+
+        def _default_getitems(*args):
+            return dict((key, self.get_option(key)) for key in args)
+
+        def _default_getitems_default(default=None, *args):
+            return dict((key, self.get_option_default(key, default)) for key in args)
+
+        def _default_default_getter(key, default):
+            try:
+                return self.get_option(key)
+            except KeyError:
+                return default
+
+        self._getter = getter
+        self._setter = setter
+
+        self._haver = haver or _default_haver
+        self._updater = updater or _default_updater
+        self._getitems = getitems or _default_getitems
+        self._getitemsdefault = getitemsdefault or _default_getitems_default
+        self._defaultsetter = defaultsetter or _default_default_setter
+        self._defaultgetter = defaultgetter or _default_default_getter
+
+    def get_option(self, key):
+        return self._getter(key)
+
+    def get_option_default(self, key, default=None):
+        return self._defaultgetter(key, default)
+
+    def set_option(self, key, value):
+        return self._setter(key, value)
+
+    def set_option_default(self, key, default=None):
+        return self._defaultsetter(key, default)
+
+    def has_option(self, key):
+        return self._haver(key)
+
+    def set_options(self, **kwargs):
+        return self._updater(**kwargs)
+
+    def get_options(self, *args):
+        return self._getitems(*args)
+
+    def get_options_default(self, default=None, *args):
+        return self._getitemsdefault(default, *args)
+
+
+class HashiVaultConnectionOptions:
+    # url
+    # proxies
+    # ca_cert
+    # validate_certs
+
+    def __init__(self, option_adapter):
+        self._options = option_adapter
+
+    def get_connection_options(self):
+        pass
+
+    def _boolean_or_cacert(self):
+        # This is needed because of this (https://hvac.readthedocs.io/en/stable/source/hvac_v1.html):
+        #
+        # # verify (Union[bool,str]) - Either a boolean to indicate whether TLS verification should
+        # # be performed when sending requests to Vault, or a string pointing at the CA bundle to use for verification.
+        #
+        '''return a bool or cacert'''
+        ca_cert = self._options.get_option('ca_cert')
+
+        validate_certs = self._options.get_option('validate_certs')
+
+        if validate_certs is None:
+            # Validate certs option was not explicitly set
+
+            # Check if VAULT_SKIP_VERIFY is set
+            vault_skip_verify = os.environ.get('VAULT_SKIP_VERIFY')
+
+            if vault_skip_verify is not None:
+                # VAULT_SKIP_VERIFY is set
+                try:
+                    # Check that we have a boolean value
+                    vault_skip_verify = check_type_bool(vault_skip_verify)
+                    # Use the inverse of VAULT_SKIP_VERIFY
+                    validate_certs = not vault_skip_verify
+                except TypeError:
+                    # Not a boolean value fallback to default value (True)
+                    validate_certs = True
+            else:
+                validate_certs = True
+
+        if not (validate_certs and ca_cert):
+            self._options.set_option('ca_cert', validate_certs)

--- a/plugins/module_utils/hashi_vault_common.py
+++ b/plugins/module_utils/hashi_vault_common.py
@@ -168,11 +168,34 @@ class HashiVaultOptionAdapter(object):
         return self._getfilleditems(*args)
 
 
+class HashiVaultOptionGroupBase:
+    '''A base class for class option group classes'''
+
+    # for now copying here
+    # going to re-think where to specify these
+    _LOW_PRECEDENCE_ENV_VAR_OPTIONS = {
+        'token_path': ['HOME'],
+        'namespace': ['VAULT_NAMESPACE'],
+        'token': ['VAULT_TOKEN'],
+        'url': ['VAULT_ADDR'],
+    }
+
     def __init__(self, option_adapter):
         self._options = option_adapter
 
-    def get_connection_options(self):
-        pass
+    def process_low_preference_env_vars(self, option_vars=None):
+        ov = option_vars or self._LOW_PRECEDENCE_ENV_VAR_OPTIONS
+        for opt, envs in ov.items():
+            for env in envs:
+                if self._options.has_option(opt) and self._options.get_option(opt) is None:
+                    self._options.set_option(opt, os.environ.get(env))
+
+
+class HashiVaultConnectionOptions(HashiVaultOptionGroupBase):
+    '''HashiVault option group class for connection options'''
+
+    def __init__(self, option_adapter):
+        super(HashiVaultConnectionOptions, self).__init__(option_adapter)
 
     def _boolean_or_cacert(self):
         # This is needed because of this (https://hvac.readthedocs.io/en/stable/source/hvac_v1.html):

--- a/plugins/module_utils/hashi_vault_common.py
+++ b/plugins/module_utils/hashi_vault_common.py
@@ -197,6 +197,31 @@ class HashiVaultConnectionOptions(HashiVaultOptionGroupBase):
     def __init__(self, option_adapter):
         super(HashiVaultConnectionOptions, self).__init__(option_adapter)
 
+    def _process_option_proxies(self):
+        '''check if 'proxies' option is dict or str and set it appropriately'''
+
+        proxies_opt = self._options.get_option('proxies')
+
+        if proxies_opt is None:
+            return
+
+        try:
+            # if it can be interpreted as dict
+            # do it
+            proxies = check_type_dict(proxies_opt)
+        except TypeError:
+            # if it can't be interpreted as dict
+            proxy = check_type_str(proxies_opt)
+            # but can be interpreted as str
+            # use this str as http and https proxy
+            proxies = {
+                'http': proxy,
+                'https': proxy,
+            }
+
+        # record the new/interpreted value for 'proxies' option
+        self._options.set_option('proxies', proxies)
+
     def _boolean_or_cacert(self):
         # This is needed because of this (https://hvac.readthedocs.io/en/stable/source/hvac_v1.html):
         #

--- a/plugins/plugin_utils/hashi_vault_plugin.py
+++ b/plugins/plugin_utils/hashi_vault_plugin.py
@@ -16,7 +16,7 @@ display = Display()
 
 
 class HashiVaultPlugin(AnsiblePlugin):
-    def __init__(self, loader=None, templar=None, **kwargs):
+    def __init__(self):
         super(HashiVaultPlugin, self).__init__()
 
         self.helper = HashiVaultHelper()

--- a/plugins/plugin_utils/hashi_vault_plugin.py
+++ b/plugins/plugin_utils/hashi_vault_plugin.py
@@ -25,10 +25,15 @@ class HashiVaultPlugin(AnsiblePlugin):
         '''processes deprecations related to the collection'''
 
         # TODO: this is a workaround for deprecations not being shown in lookups
-        # See: https://github.com/ansible/ansible/issues/73051
-        # Fix: https://github.com/ansible/ansible/pull/73058
+        # See:
+        #  - https://github.com/ansible/ansible/issues/73051
+        #  - https://github.com/ansible/ansible/pull/73058
+        #  - https://github.com/ansible/ansible/pull/73239
+        #  - https://github.com/ansible/ansible/pull/73240
         #
-        # If #73058 or another fix is backported, this should be removed.
+        # If a fix is backported to 2.9, this should be removed.
+        # Otherwise, we'll have to test with fixes that are available and see how we
+        # can determine whether to execute this conditionally.
 
         # nicked from cli/__init__.py
         # with slight customizations to help filter out relevant messages

--- a/plugins/plugin_utils/hashi_vault_plugin.py
+++ b/plugins/plugin_utils/hashi_vault_plugin.py
@@ -10,7 +10,11 @@ from ansible.plugins import AnsiblePlugin
 from ansible import constants as C
 from ansible.utils.display import Display
 
-from ansible_collections.community.hashi_vault.plugins.module_utils.hashi_vault_common import HashiVaultHelper
+from ansible_collections.community.hashi_vault.plugins.module_utils.hashi_vault_common import (
+    HashiVaultHelper,
+    HashiVaultOptionAdapter,
+    HashiVaultConnectionOptions,
+)
 
 display = Display()
 
@@ -20,6 +24,8 @@ class HashiVaultPlugin(AnsiblePlugin):
         super(HashiVaultPlugin, self).__init__()
 
         self.helper = HashiVaultHelper()
+        self._options_adapter = HashiVaultOptionAdapter.from_ansible_plugin(self)
+        self.connection_options = HashiVaultConnectionOptions(self._options_adapter)
 
     def process_deprecations(self, collection_name='community.hashi_vault'):
         '''processes deprecations related to the collection'''

--- a/tests/unit/plugins/base/test_hashi_vault_lookup_base.py
+++ b/tests/unit/plugins/base/test_hashi_vault_lookup_base.py
@@ -57,6 +57,8 @@ class TestHashiVaultLookupBase(object):
             ('value1 key2=value2 key3=val_w/=in_it key4=value4', None),
             ('key1=value1 value2 key3=val_w/=in_it key4=value4', None),
             ('key1=value1 value2 key3=val_w/=in_it key4=value4', 'key2'),
+            ('key1=val1 invalid key3=val3', None),
+            ('key1=val1 invalid key3=val3', 'key1'),
         ]
     )
     def test_parse_kev_term_invalid_term_strings(self, term, unqualified, hashi_vault_lookup_module):

--- a/tests/unit/plugins/base/test_hashi_vault_plugin.py
+++ b/tests/unit/plugins/base/test_hashi_vault_plugin.py
@@ -9,7 +9,10 @@ import pytest
 
 from ansible.plugins import AnsiblePlugin
 
-from ansible_collections.community.hashi_vault.plugins.plugin_utils.hashi_vault_plugin import HashiVaultPlugin
+from ansible_collections.community.hashi_vault.plugins.plugin_utils.hashi_vault_plugin import (
+    HashiVaultPlugin,
+    HashiVaultOptionAdapter,
+)
 
 
 @pytest.fixture
@@ -21,6 +24,9 @@ class TestHashiVaultPlugin(object):
 
     def test_is_ansible_plugin(self, hashi_vault_plugin):
         assert issubclass(type(hashi_vault_plugin), AnsiblePlugin)
+
+    def test_has_option_adapter(self, hashi_vault_plugin):
+        assert hasattr(hashi_vault_plugin, '_options_adapter') and issubclass(type(hashi_vault_plugin._options_adapter), HashiVaultOptionAdapter)
 
     # TODO: remove when deprecate() is no longer needed
     def test_has_process_deprecations(self, hashi_vault_plugin):

--- a/tests/unit/plugins/base/test_hashi_vault_plugin.py
+++ b/tests/unit/plugins/base/test_hashi_vault_plugin.py
@@ -9,10 +9,8 @@ import pytest
 
 from ansible.plugins import AnsiblePlugin
 
-from ansible_collections.community.hashi_vault.plugins.plugin_utils.hashi_vault_plugin import (
-    HashiVaultPlugin,
-    HashiVaultOptionAdapter,
-)
+from ansible_collections.community.hashi_vault.plugins.plugin_utils.hashi_vault_plugin import HashiVaultPlugin
+from ansible_collections.community.hashi_vault.plugins.module_utils.hashi_vault_common import HashiVaultOptionAdapter
 
 
 @pytest.fixture

--- a/tests/unit/plugins/module_utils/test_hashi_vault_connection_options.py
+++ b/tests/unit/plugins/module_utils/test_hashi_vault_connection_options.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 Brian Scholer (@briantist)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import pytest
+
+from ansible_collections.community.hashi_vault.tests.unit.compat import mock
+
+from ansible_collections.community.hashi_vault.plugins.module_utils.hashi_vault_common import (
+    HashiVaultOptionGroupBase,
+    HashiVaultConnectionOptions,
+    HashiVaultOptionAdapter,
+)
+
+
+CONNECTION_OPTIONS = {
+    'url': 'https://127.0.0.1',
+    'proxies': None,
+    'namespace': None,
+    'validate_certs': None,
+    'ca_cert': None,
+}
+
+@pytest.fixture
+def predefined_options():
+    return CONNECTION_OPTIONS.copy()
+
+
+@pytest.fixture
+def adapter(predefined_options):
+    return HashiVaultOptionAdapter.from_dict(predefined_options)
+
+
+@pytest.fixture
+def connection_options(adapter):
+    return HashiVaultConnectionOptions(adapter)
+
+
+class TestHashiVaultConnectionOptions(object):
+    def test_connection_options_is_option_group(self, connection_options):
+        assert issubclass(type(connection_options), HashiVaultOptionGroupBase)
+
+    # _boolean_or_cacert tests
+    # this method is the intersection of the validate_certs and ca_cert parameter
+    # along with the VAULT_SKIP_VERIFY environment variable (see the function defintion).
+    # The result is either a boolean, or a string, to be passed to the hvac client's
+    # verify parameter.
+
+    @pytest.mark.parametrize(
+        'optpatch,envpatch,expected',
+        [
+            ({}, {}, True),
+            ({}, {'VAULT_SKIP_VERIFY': 'true'}, False),
+            ({}, {'VAULT_SKIP_VERIFY': 'false'}, True),
+            ({}, {'VAULT_SKIP_VERIFY': 'invalid'}, True),
+            ({'validate_certs': True}, {}, True),
+            ({'validate_certs': True}, {'VAULT_SKIP_VERIFY': 'false'}, True),
+            ({'validate_certs': True}, {'VAULT_SKIP_VERIFY': 'true'}, True),
+            ({'validate_certs': True}, {'VAULT_SKIP_VERIFY': 'invalid'}, True),
+            ({'validate_certs': False}, {}, False),
+            ({'validate_certs': False}, {'VAULT_SKIP_VERIFY': 'false'}, False),
+            ({'validate_certs': False}, {'VAULT_SKIP_VERIFY': 'true'}, False),
+            ({'validate_certs': False}, {'VAULT_SKIP_VERIFY': 'invalid'}, False),
+            ({'ca_cert': '/tmp/fake'}, {}, '/tmp/fake'),
+            ({'ca_cert': '/tmp/fake'}, {'VAULT_SKIP_VERIFY': 'true'}, False),
+            ({'ca_cert': '/tmp/fake'}, {'VAULT_SKIP_VERIFY': 'false'}, '/tmp/fake'),
+            ({'ca_cert': '/tmp/fake'}, {'VAULT_SKIP_VERIFY': 'invalid'}, '/tmp/fake'),
+            ({'ca_cert': '/tmp/fake', 'validate_certs': True}, {}, '/tmp/fake'),
+            ({'ca_cert': '/tmp/fake', 'validate_certs': True}, {'VAULT_SKIP_VERIFY': 'false'}, '/tmp/fake'),
+            ({'ca_cert': '/tmp/fake', 'validate_certs': True}, {'VAULT_SKIP_VERIFY': 'true'}, '/tmp/fake'),
+            ({'ca_cert': '/tmp/fake', 'validate_certs': True}, {'VAULT_SKIP_VERIFY': 'invalid'}, '/tmp/fake'),
+            ({'ca_cert': '/tmp/fake', 'validate_certs': False}, {}, False),
+            ({'ca_cert': '/tmp/fake', 'validate_certs': False}, {'VAULT_SKIP_VERIFY': 'false'}, False),
+            ({'ca_cert': '/tmp/fake', 'validate_certs': False}, {'VAULT_SKIP_VERIFY': 'true'}, False),
+            ({'ca_cert': '/tmp/fake', 'validate_certs': False}, {'VAULT_SKIP_VERIFY': 'invalid'}, False),
+        ]
+    )
+    def test_boolean_or_cacert(self, connection_options, predefined_options, adapter, optpatch, envpatch, expected):
+        adapter.set_options(**optpatch)
+
+        with mock.patch.dict(os.environ, envpatch):
+            connection_options._boolean_or_cacert()
+
+        assert predefined_options['ca_cert'] == expected

--- a/tests/unit/plugins/module_utils/test_hashi_vault_option_adapter.py
+++ b/tests/unit/plugins/module_utils/test_hashi_vault_option_adapter.py
@@ -27,6 +27,7 @@ SAMPLE_KEYS = sorted(list(SAMPLE_DICT.keys()))
 
 MISSING_KEYS = ['no', 'nein', 'iie']
 
+
 class FakePlugin(AnsiblePlugin):
     _load_name = 'community.hashi_vault.fake'
 
@@ -37,9 +38,11 @@ class SentinelMarker():
 
 MARKER = SentinelMarker()
 
+
 @pytest.fixture()
 def sample_dict():
     return SAMPLE_DICT.copy()
+
 
 @pytest.fixture
 def ansible_plugin(sample_dict):
@@ -47,13 +50,16 @@ def ansible_plugin(sample_dict):
     plugin._options = sample_dict
     return plugin
 
+
 @pytest.fixture
 def adapter_from_dict(sample_dict):
     return HashiVaultOptionAdapter.from_dict(sample_dict)
 
+
 @pytest.fixture
 def adapter_from_ansible_plugin(ansible_plugin):
     return HashiVaultOptionAdapter.from_ansible_plugin(ansible_plugin)
+
 
 @pytest.fixture(params=['dict', 'ansible_plugin'])
 def adapter(request, adapter_from_dict, adapter_from_ansible_plugin):
@@ -62,18 +68,14 @@ def adapter(request, adapter_from_dict, adapter_from_ansible_plugin):
         'ansible_plugin': adapter_from_ansible_plugin,
     }[request.param]
 
-# @pytest.fixture
-# def hashi_vault_option_adapter():
-#     return HashiVaultHelper()
 
-    #| _getter = None
-    #| _setter = None
-    #| _haver = None
-    #| _updater = None
-    #| _getitems = None
-    # _getitemsdefault
-    #| _defaultsetter = None
-    #| _defaultgetter
+    # #| _getter = None
+    # #| _setter = None
+    # #| _haver = None
+    # #| _updater = None
+    # #| _getitems = None
+    # #| _defaultsetter = None
+    # #| _defaultgetter
 
 
 # @pytest.mark.skipif(sys.version_info < (2, 7), reason="Python 2.7 or higher is required.")
@@ -108,12 +110,12 @@ class TestHashiVaultOptionAdapter(object):
 
         assert isinstance(value, SentinelMarker)
 
-    @pytest.mark.parametrize('option,expected', [(o, False) for o in MISSING_KEYS]+[(o, True) for o in SAMPLE_KEYS])
+    @pytest.mark.parametrize('option,expected', [(o, False) for o in MISSING_KEYS] + [(o, True) for o in SAMPLE_KEYS])
     def test_has_option(self, adapter, option, expected):
         assert adapter.has_option(option) == expected
 
     @pytest.mark.parametrize('value', ['__VALUE'])
-    @pytest.mark.parametrize('option', (SAMPLE_KEYS+MISSING_KEYS))
+    @pytest.mark.parametrize('option', (SAMPLE_KEYS + MISSING_KEYS))
     def test_set_option(self, adapter, option, value, sample_dict):
         adapter.set_option(option, value)
 
@@ -122,7 +124,7 @@ class TestHashiVaultOptionAdapter(object):
         assert adapter.get_option(option) == value
 
     @pytest.mark.parametrize('default', [MARKER])
-    @pytest.mark.parametrize('option,expected', [(o, SAMPLE_DICT[o]) for o in SAMPLE_KEYS]+[(o, MARKER) for o in MISSING_KEYS])
+    @pytest.mark.parametrize('option,expected', [(o, SAMPLE_DICT[o]) for o in SAMPLE_KEYS] + [(o, MARKER) for o in MISSING_KEYS])
     def test_set_option_default(self, adapter, option, default, expected, sample_dict):
         value = adapter.set_option_default(option, default)
 
@@ -167,51 +169,3 @@ class TestHashiVaultOptionAdapter(object):
         result = adapter.get_options(*options)
 
         assert result == expected
-
-    @pytest.mark.parametrize('options', [SAMPLE_KEYS[0:2]])
-    def test_get_options_default_exists(self, adapter, options):
-        expected = dict([(k, SAMPLE_DICT[k]) for k in options])
-
-        result = adapter.get_options_default(MARKER, *options)
-
-        assert result == expected
-
-    @pytest.mark.parametrize('options', [MISSING_KEYS[0:2]])
-    def test_get_options_default_missing(self, adapter, options):
-        expected = dict.fromkeys(options, MARKER)
-
-        result = adapter.get_options_default(MARKER, *options)
-
-        assert result == expected
-
-    @pytest.mark.parametrize('options', [[SAMPLE_KEYS[0], MISSING_KEYS[0]]])
-    def test_get_options_default_mixed(self, adapter, options):
-        result = adapter.get_options_default(MARKER, *options)
-
-        for o in options:
-            assert result[o] == SAMPLE_DICT.get(o, MARKER)
-            assert result[o] == adapter.get_option_default(o, MARKER)
-
-    @pytest.mark.parametrize('options', [SAMPLE_KEYS[0:2]])
-    def test_get_options_default_exists_no_default(self, adapter, options):
-        expected = dict([(k, SAMPLE_DICT[k]) for k in options])
-
-        result = adapter.get_options_default(*options)
-
-        assert result == expected
-
-    @pytest.mark.parametrize('options', [MISSING_KEYS[0:2]])
-    def test_get_options_default_missing_no_default(self, adapter, options):
-        expected = dict.fromkeys(options, None)
-
-        result = adapter.get_options_default(*options)
-
-        assert result == expected
-
-    @pytest.mark.parametrize('options', [[SAMPLE_KEYS[0], MISSING_KEYS[0]]])
-    def test_get_options_default_mixed_no_default(self, adapter, options):
-        result = adapter.get_options_default(*options)
-
-        for o in options:
-            assert result[o] == SAMPLE_DICT.get(o, None)
-            assert result[o] == adapter.get_option_default(o, None)

--- a/tests/unit/plugins/module_utils/test_hashi_vault_option_adapter.py
+++ b/tests/unit/plugins/module_utils/test_hashi_vault_option_adapter.py
@@ -140,7 +140,7 @@ class TestHashiVaultOptionAdapter(object):
         assert sample_dict[option] == expected
         assert adapter.get_option(option) == expected
 
-    @pytest.mark.parametrize('options', [SAMPLE_KEYS[0], MISSING_KEYS[0]])
+    @pytest.mark.parametrize('options', [[SAMPLE_KEYS[0], MISSING_KEYS[0]]])
     def test_set_options(self, adapter, options, sample_dict):
         update = dict([(o, '__VALUE_%i' % i) for i, o in enumerate(options)])
 
@@ -154,7 +154,7 @@ class TestHashiVaultOptionAdapter(object):
         for k in MISSING_KEYS:
             if k in update:
                 assert sample_dict[k] == update[k]
-                assert adapter.get_option(k) == expected
+                assert adapter.get_option(k) == update[k]
             else:
                 assert k not in sample_dict
                 assert not adapter.has_option(k)

--- a/tests/unit/plugins/module_utils/test_hashi_vault_option_adapter.py
+++ b/tests/unit/plugins/module_utils/test_hashi_vault_option_adapter.py
@@ -213,7 +213,7 @@ class TestHashiVaultOptionAdapter(object):
         assert result == expected
 
     @pytest.mark.parametrize('options', [SAMPLE_KEYS])
-    def test_get_filtered_options_by_value(self, adapter, options, filter_key_in_range):
+    def test_get_filtered_options_by_key(self, adapter, options, filter_key_in_range):
         expected = dict([(k, SAMPLE_DICT[k]) for k in options if k in SAMPLE_KEYS[1:3]])
 
         result = adapter.get_filtered_options(filter_key_in_range, *options)

--- a/tests/unit/plugins/module_utils/test_hashi_vault_option_adapter.py
+++ b/tests/unit/plugins/module_utils/test_hashi_vault_option_adapter.py
@@ -53,12 +53,18 @@ def ansible_plugin(sample_dict):
 
 @pytest.fixture
 def adapter_from_dict(sample_dict):
-    return HashiVaultOptionAdapter.from_dict(sample_dict)
+    def _create_adapter_from_dict():
+        return HashiVaultOptionAdapter.from_dict(sample_dict)
+
+    return _create_adapter_from_dict
 
 
 @pytest.fixture
 def adapter_from_ansible_plugin(ansible_plugin):
-    return HashiVaultOptionAdapter.from_ansible_plugin(ansible_plugin)
+    def _create_adapter_from_ansible_plugin():
+        return HashiVaultOptionAdapter.from_ansible_plugin(ansible_plugin)
+
+    return _create_adapter_from_ansible_plugin
 
 
 @pytest.fixture(params=['dict', 'ansible_plugin'])
@@ -66,7 +72,7 @@ def adapter(request, adapter_from_dict, adapter_from_ansible_plugin):
     return {
         'dict': adapter_from_dict,
         'ansible_plugin': adapter_from_ansible_plugin,
-    }[request.param]
+    }[request.param]()
 
 
     # #| _getter = None

--- a/tests/unit/plugins/module_utils/test_hashi_vault_option_adapter.py
+++ b/tests/unit/plugins/module_utils/test_hashi_vault_option_adapter.py
@@ -57,6 +57,16 @@ def adapter_from_dict(sample_dict):
 
 
 @pytest.fixture
+def adapter_from_dict_defaults(sample_dict):
+    # the point of this one is to test the "default" methods provided by the adapter
+    # for everything except getter and setter, so we only supply those two required methods
+    def _create_adapter_from_dict_defaults():
+        return HashiVaultOptionAdapter(getter=sample_dict.__getitem__, setter=sample_dict.__setitem__)
+
+    return _create_adapter_from_dict_defaults
+
+
+@pytest.fixture
 def adapter_from_ansible_plugin(ansible_plugin):
     def _create_adapter_from_ansible_plugin():
         return HashiVaultOptionAdapter.from_ansible_plugin(ansible_plugin)
@@ -64,10 +74,11 @@ def adapter_from_ansible_plugin(ansible_plugin):
     return _create_adapter_from_ansible_plugin
 
 
-@pytest.fixture(params=['dict', 'ansible_plugin'])
-def adapter(request, adapter_from_dict, adapter_from_ansible_plugin):
+@pytest.fixture(params=['dict', 'dict_defaults', 'ansible_plugin'])
+def adapter(request, adapter_from_dict, adapter_from_dict_defaults, adapter_from_ansible_plugin):
     return {
         'dict': adapter_from_dict,
+        'dict_defaults': adapter_from_dict_defaults,
         'ansible_plugin': adapter_from_ansible_plugin,
     }[request.param]()
 

--- a/tests/unit/plugins/module_utils/test_hashi_vault_option_adapter.py
+++ b/tests/unit/plugins/module_utils/test_hashi_vault_option_adapter.py
@@ -1,0 +1,217 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 Brian Scholer (@briantist)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import sys
+import os
+import pytest
+
+from ansible.plugins import AnsiblePlugin
+# from ansible.plugins.loader import lookup_loader
+
+from ansible_collections.community.hashi_vault.tests.unit.compat import mock
+from ansible_collections.community.hashi_vault.plugins.module_utils.hashi_vault_common import HashiVaultOptionAdapter
+
+
+SAMPLE_DICT = {
+    'key1': 'val1',
+    'key2': 2,
+    'key3': 'three',
+    'key4': 'iiii',
+}
+
+SAMPLE_KEYS = sorted(list(SAMPLE_DICT.keys()))
+
+MISSING_KEYS = ['no', 'nein', 'iie']
+
+class FakePlugin(AnsiblePlugin):
+    _load_name = 'community.hashi_vault.fake'
+
+
+class SentinelMarker():
+    pass
+
+
+MARKER = SentinelMarker()
+
+@pytest.fixture()
+def sample_dict():
+    return SAMPLE_DICT.copy()
+
+@pytest.fixture
+def ansible_plugin(sample_dict):
+    plugin = FakePlugin()
+    plugin._options = sample_dict
+    return plugin
+
+@pytest.fixture
+def adapter_from_dict(sample_dict):
+    return HashiVaultOptionAdapter.from_dict(sample_dict)
+
+@pytest.fixture
+def adapter_from_ansible_plugin(ansible_plugin):
+    return HashiVaultOptionAdapter.from_ansible_plugin(ansible_plugin)
+
+@pytest.fixture(params=['dict', 'ansible_plugin'])
+def adapter(request, adapter_from_dict, adapter_from_ansible_plugin):
+    return {
+        'dict': adapter_from_dict,
+        'ansible_plugin': adapter_from_ansible_plugin,
+    }[request.param]
+
+# @pytest.fixture
+# def hashi_vault_option_adapter():
+#     return HashiVaultHelper()
+
+    #| _getter = None
+    #| _setter = None
+    #| _haver = None
+    #| _updater = None
+    #| _getitems = None
+    # _getitemsdefault
+    #| _defaultsetter = None
+    #| _defaultgetter
+
+
+# @pytest.mark.skipif(sys.version_info < (2, 7), reason="Python 2.7 or higher is required.")
+class TestHashiVaultOptionAdapter(object):
+
+    @pytest.mark.parametrize('option', SAMPLE_KEYS)
+    def test_get_option_succeeds(self, adapter, option):
+        value = adapter.get_option(option)
+
+        assert value == SAMPLE_DICT[option]
+
+    @pytest.mark.parametrize('option', SAMPLE_KEYS)
+    def test_get_option_default_succeeds(self, adapter, option):
+        value = adapter.get_option_default(option, MARKER)
+
+        assert value == SAMPLE_DICT[option]
+
+    @pytest.mark.parametrize('option', MISSING_KEYS)
+    def test_get_option_missing_raises(self, adapter, option):
+        with pytest.raises(KeyError):
+            adapter.get_option(option)
+
+    @pytest.mark.parametrize('option', SAMPLE_KEYS)
+    def test_get_option_default_succeeds(self, adapter, option):
+        value = adapter.get_option_default(option, MARKER)
+
+        assert value == SAMPLE_DICT[option]
+
+    @pytest.mark.parametrize('option', MISSING_KEYS)
+    def test_get_option_default_missing_returns_default(self, adapter, option):
+        value = adapter.get_option_default(option, MARKER)
+
+        assert isinstance(value, SentinelMarker)
+
+    @pytest.mark.parametrize('option,expected', [(o, False) for o in MISSING_KEYS]+[(o, True) for o in SAMPLE_KEYS])
+    def test_has_option(self, adapter, option, expected):
+        assert adapter.has_option(option) == expected
+
+    @pytest.mark.parametrize('value', ['__VALUE'])
+    @pytest.mark.parametrize('option', (SAMPLE_KEYS+MISSING_KEYS))
+    def test_set_option(self, adapter, option, value, sample_dict):
+        adapter.set_option(option, value)
+
+        # first check the underlying data, then ensure the adapter refelcts the change too
+        assert sample_dict[option] == value
+        assert adapter.get_option(option) == value
+
+    @pytest.mark.parametrize('default', [MARKER])
+    @pytest.mark.parametrize('option,expected', [(o, SAMPLE_DICT[o]) for o in SAMPLE_KEYS]+[(o, MARKER) for o in MISSING_KEYS])
+    def test_set_option_default(self, adapter, option, default, expected, sample_dict):
+        value = adapter.set_option_default(option, default)
+
+        # check return data, underlying data structure, and adapter retrieval
+        assert value == expected
+        assert sample_dict[option] == expected
+        assert adapter.get_option(option) == expected
+
+    @pytest.mark.parametrize('options', [SAMPLE_KEYS[0], MISSING_KEYS[0]])
+    def test_set_options(self, adapter, options, sample_dict):
+        update = dict([(o, '__VALUE_%i' % i) for i, o in enumerate(options)])
+
+        adapter.set_options(**update)
+
+        for k in SAMPLE_KEYS:
+            expected = update[k] if k in update else SAMPLE_DICT[k]
+            assert sample_dict[k] == expected
+            assert adapter.get_option(k) == expected
+
+        for k in MISSING_KEYS:
+            if k in update:
+                assert sample_dict[k] == update[k]
+                assert adapter.get_option(k) == expected
+            else:
+                assert k not in sample_dict
+                assert not adapter.has_option(k)
+
+    @pytest.mark.parametrize('options', [[SAMPLE_KEYS[0], MISSING_KEYS[0]]])
+    def test_get_options_mixed(self, adapter, options):
+        with pytest.raises(KeyError):
+            adapter.get_options(*options)
+
+    @pytest.mark.parametrize('options', [MISSING_KEYS[0:2]])
+    def test_get_options_missing(self, adapter, options):
+        with pytest.raises(KeyError):
+            adapter.get_options(*options)
+
+    @pytest.mark.parametrize('options', [SAMPLE_KEYS[0:2]])
+    def test_get_options_exists(self, adapter, options):
+        expected = dict([(k, SAMPLE_DICT[k]) for k in options])
+
+        result = adapter.get_options(*options)
+
+        assert result == expected
+
+    @pytest.mark.parametrize('options', [SAMPLE_KEYS[0:2]])
+    def test_get_options_default_exists(self, adapter, options):
+        expected = dict([(k, SAMPLE_DICT[k]) for k in options])
+
+        result = adapter.get_options_default(MARKER, *options)
+
+        assert result == expected
+
+    @pytest.mark.parametrize('options', [MISSING_KEYS[0:2]])
+    def test_get_options_default_missing(self, adapter, options):
+        expected = dict.fromkeys(options, MARKER)
+
+        result = adapter.get_options_default(MARKER, *options)
+
+        assert result == expected
+
+    @pytest.mark.parametrize('options', [[SAMPLE_KEYS[0], MISSING_KEYS[0]]])
+    def test_get_options_default_mixed(self, adapter, options):
+        result = adapter.get_options_default(MARKER, *options)
+
+        for o in options:
+            assert result[o] == SAMPLE_DICT.get(o, MARKER)
+            assert result[o] == adapter.get_option_default(o, MARKER)
+
+    @pytest.mark.parametrize('options', [SAMPLE_KEYS[0:2]])
+    def test_get_options_default_exists_no_default(self, adapter, options):
+        expected = dict([(k, SAMPLE_DICT[k]) for k in options])
+
+        result = adapter.get_options_default(*options)
+
+        assert result == expected
+
+    @pytest.mark.parametrize('options', [MISSING_KEYS[0:2]])
+    def test_get_options_default_missing_no_default(self, adapter, options):
+        expected = dict.fromkeys(options, None)
+
+        result = adapter.get_options_default(*options)
+
+        assert result == expected
+
+    @pytest.mark.parametrize('options', [[SAMPLE_KEYS[0], MISSING_KEYS[0]]])
+    def test_get_options_default_mixed_no_default(self, adapter, options):
+        result = adapter.get_options_default(*options)
+
+        for o in options:
+            assert result[o] == SAMPLE_DICT.get(o, None)
+            assert result[o] == adapter.get_option_default(o, None)

--- a/tests/unit/plugins/module_utils/test_hashi_vault_option_adapter.py
+++ b/tests/unit/plugins/module_utils/test_hashi_vault_option_adapter.py
@@ -100,12 +100,6 @@ class TestHashiVaultOptionAdapter(object):
 
         assert value == SAMPLE_DICT[option]
 
-    @pytest.mark.parametrize('option', SAMPLE_KEYS)
-    def test_get_option_default_succeeds(self, adapter, option):
-        value = adapter.get_option_default(option, MARKER)
-
-        assert value == SAMPLE_DICT[option]
-
     @pytest.mark.parametrize('option', MISSING_KEYS)
     def test_get_option_missing_raises(self, adapter, option):
         with pytest.raises(KeyError):

--- a/tests/unit/plugins/module_utils/test_hashi_vault_option_group_base.py
+++ b/tests/unit/plugins/module_utils/test_hashi_vault_option_group_base.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 Brian Scholer (@briantist)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import pytest
+
+from ansible_collections.community.hashi_vault.tests.unit.compat import mock
+
+from ansible_collections.community.hashi_vault.plugins.module_utils.hashi_vault_common import (
+    HashiVaultOptionGroupBase,
+    HashiVaultOptionAdapter,
+)
+
+
+PREREAD_OPTIONS = {
+    'opt1': 'val1',
+    'opt2': None,
+    'opt3': 'val3',
+    'opt4': None,
+}
+
+LOW_PREF_DEF = {
+    'opt1': ['_ENV_1A'],
+    'opt2': ['_ENV_2A', '_ENV_2B'],
+    'opt4': ['_ENV_4A', '_ENV_4B', '_ENV_4C'],
+    'opt5': ['_ENV_5A'],
+}
+
+
+@pytest.fixture
+def preread_options():
+    return PREREAD_OPTIONS.copy()
+
+
+@pytest.fixture
+def adapter(preread_options):
+    return HashiVaultOptionAdapter.from_dict(preread_options)
+
+
+@pytest.fixture
+def option_group_base(adapter):
+    return HashiVaultOptionGroupBase(adapter)
+
+
+@pytest.fixture(params=[
+    # env, expected
+    ({}, {}),
+    ({'_ENV_1A': 'alt1a'}, {}),
+    ({'_ENV_3X': 'noop3x'}, {}),
+    ({'_ENV_2B': 'alt2b'}, {'opt2': 'alt2b'}),
+    ({'_ENV_2A': 'alt2a', '_ENV_2B': 'alt2b'}, {'opt2': 'alt2a'}),
+    ({'_ENV_4B': 'alt4b', '_ENV_4C': 'alt4c'}, {'opt4': 'alt4b'}),
+    ({'_ENV_1A': 'alt1a', '_ENV_4A': 'alt4a', '_ENV_1B': 'noop1b', '_ENV_4C': 'alt4c'}, {'opt4': 'alt4a'}),
+    ({'_ENV_5A': 'noop5a', '_ENV_4C': 'alt4c', '_ENV_2A': 'alt2a'}, {'opt2': 'alt2a', 'opt4': 'alt4c'}),
+])
+def with_env(request, preread_options):
+    expected = preread_options.copy()
+    expected.update(request.param[1])
+    with mock.patch.dict(os.environ, request.param[0]):
+        yield expected
+
+
+class TestHashiVaultOptionGroupBase(object):
+
+    def test_process_low_preference_env_vars(self, option_group_base, with_env, preread_options):
+        option_group_base.process_low_preference_env_vars(LOW_PREF_DEF)
+
+        assert preread_options == with_env , "Expected: %r\nGot: %r" % (with_env, preread_options)

--- a/tests/unit/plugins/module_utils/test_hashi_vault_option_group_base.py
+++ b/tests/unit/plugins/module_utils/test_hashi_vault_option_group_base.py
@@ -47,7 +47,10 @@ def option_group_base(adapter):
 
 
 @pytest.fixture(params=[
-    # env, expected
+    # first dict is used to patch the environment vars
+    # second dict is used to patch the current options to get them to the expected state
+    #
+    # envpatch, expatch
     ({}, {}),
     ({'_ENV_1A': 'alt1a'}, {}),
     ({'_ENV_3X': 'noop3x'}, {}),
@@ -58,9 +61,12 @@ def option_group_base(adapter):
     ({'_ENV_5A': 'noop5a', '_ENV_4C': 'alt4c', '_ENV_2A': 'alt2a'}, {'opt2': 'alt2a', 'opt4': 'alt4c'}),
 ])
 def with_env(request, preread_options):
+    envpatch, expatch = request.param
+
     expected = preread_options.copy()
-    expected.update(request.param[1])
-    with mock.patch.dict(os.environ, request.param[0]):
+    expected.update(expatch)
+
+    with mock.patch.dict(os.environ, envpatch):
         yield expected
 
 
@@ -69,4 +75,4 @@ class TestHashiVaultOptionGroupBase(object):
     def test_process_low_preference_env_vars(self, option_group_base, with_env, preread_options):
         option_group_base.process_low_preference_env_vars(LOW_PREF_DEF)
 
-        assert preread_options == with_env , "Expected: %r\nGot: %r" % (with_env, preread_options)
+        assert preread_options == with_env, "Expected: %r\nGot: %r" % (with_env, preread_options)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

This follows on the heels of #55 , and is a little big but I'll try to break down the changes and what's happening.

### Options Adapter
The `HashiVaultOptionAdapter` class provides a consistent interface for accessing options, and lives in module_utils.

The goal is to have logic for dealing with various common options in module_utils so that it can be shared among plugins and eventually modules as well. But options are accessed differently between plugins via Config Manager and modules via AnsibleModule.

Config Manager uses a dict internally, but it's not meant to be interacted with directly. As learned from the deprecations incident and described in #35 , the ensure the best future compatibility it's best to ensure all option access goes through Config Manager's public methods, and that options aren't accessed when not needed.

To that end I want to ensure that the logic of processing options doesn't need to know where the option came from, but passing in all the options it might need at once isn't ideal either, as it puts too much responsibility on the caller, and may cause unnecessary option access.

The adapter allows these methods to work consistently regardless of the source.

The adapter has class methods to easily create instances from a dict directly or from a AnsiblePlugin. I'll make one for AnsibleModule later (which is probably just going to call the dict version anyway).

The adapter class has a full suite of unit tests (issues caught in writing those led to a few changes in design, love it!)

---

### Option Group Base Class
`HashiVaultOptiongroupBase` is a base class for what I'm tentatively calling "option groups" and the classes that will handle them. For now the functionality of processing low preference environment variables was moved here (along with the hardcoded list of them). That's probably going to change a bit as time goes on.

### Connection Options Group
`HashiVaultConnectionOptions` is the first options group class, encompassing the options needed to make a connection to Vault. So the methods responsible for processing those options moved as well, and were changed to use the adapter.

---

### Doc fragment
The connection options were moved to a doc fragment.

There's a few other small changes, test improvements, etc. scattered in here.

---

### What's Next in this Project
In the short term: I'd introduce a diff immediately after this one that renames the module_util with an underscore `_` adds a docstring for python compatibility, and a comment specifying that it's private. This is all came from https://github.com/ansible/community/issues/539#issuecomment-780839686 . It's not in this diff because I started this before that meeting, and the rename is going to show the file as all new, so I want to separate it from other changes to not mess up the diff.

Other than that:
- I'll be looking at starting to move auth methods to dedicated classes
- I want to think about how to organize doc fragments in a way that will work better for being shared with both plugins and modules
- I want to see if some information can be extracted from doc fragments so it's not repeated elsewhere

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hashi_vault

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
