### PR TITLE
hashi_vault - Fix regression where VAULT_ADDR is ignored

### DIFF
--- a/changelogs/fragments/41-fix-vault-addr.yml
+++ b/changelogs/fragments/41-fix-vault-addr.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - hashi_vault - restore use of ``VAULT_ADDR`` environment variable as a low preference env var (https://github.com/ansible-collections/community.hashi_vault/pull/61).

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -84,13 +84,13 @@ DOCUMENTATION = """
       description:
         - URL to the Vault service.
         - If not specified by any other means, the value of the C(VAULT_ADDR) environment variable will be used.
+        - If C(VAULT_ADDR) is also not defined then a default of C(http://127.0.0.1:8200) will be used.
       env:
         - name: ANSIBLE_HASHI_VAULT_ADDR
           version_added: '0.2.0'
       ini:
         - section: lookup_hashi_vault
           key: url
-      default: 'http://127.0.0.1:8200'
     username:
       description: Authentication user name.
     password:
@@ -640,7 +640,18 @@ class LookupModule(HashiVaultLookupBase):
         # proxies (dict or str)
         self.process_option_proxies()
 
+        # apply additional defaults
+        self.apply_additional_defaults(url='http://127.0.0.1:8200')
+
     # begin options processing methods
+
+    # this is a temporary method
+    # https://github.com/ansible-collections/community.hashi_vault/pull/61
+    # low preference env vars will be updated to take defaults into account
+    def apply_additional_defaults(self, **kwargs):
+        for k, v in kwargs.items():
+            if self.get_option(k) is None:
+                self.set_option(k, v)
 
     def set_default_option_env(self, option, var):
         '''sets an option to the value of an env var if None'''

--- a/tests/unit/plugins/lookup/test_hashi_vault.py
+++ b/tests/unit/plugins/lookup/test_hashi_vault.py
@@ -5,18 +5,53 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import os
 import pytest
+
+from ansible.errors import AnsibleError
+
+from ansible.plugins.loader import lookup_loader
+
+from ansible.module_utils.six.moves.urllib.parse import urlparse
+
+from ansible_collections.community.hashi_vault.tests.unit.compat import mock
 
 from ansible_collections.community.hashi_vault.plugins.lookup.hashi_vault import LookupModule  # , HashiVault
 from ansible_collections.community.hashi_vault.plugins.lookup.__init__ import HashiVaultLookupBase
 
+from requests.exceptions import ConnectionError
+
 
 @pytest.fixture
 def hashi_vault_lookup_module():
-    return LookupModule()
+    return lookup_loader.get('community.hashi_vault.hashi_vault')
 
 
 class TestHashiVaultLookup(object):
 
     def test_is_hashi_vault_lookup_base(self, hashi_vault_lookup_module):
         assert issubclass(type(hashi_vault_lookup_module), HashiVaultLookupBase)
+
+    @pytest.mark.parametrize(
+        'envpatch,expected',
+        [
+            ({}, 'http://127.0.0.1:8200'),
+            ({'VAULT_ADDR': 'http://vault:0'}, 'http://vault:0'),
+            ({'ANSIBLE_HASHI_VAULT_ADDR': 'https://vaultalt'}, 'https://vaultalt'),
+            ({'VAULT_ADDR': 'https://vaultlow:8443', 'ANSIBLE_HASHI_VAULT_ADDR': 'http://vaulthigh:8200'}, 'http://vaulthigh:8200'),
+        ],
+    )
+    def test_vault_addr_low_pref(self, hashi_vault_lookup_module, envpatch, expected):
+        url = urlparse(expected)
+        host = url.hostname
+        port = url.port if url.port is not None else {'http': 80, 'https': 443}[url.scheme]
+
+        envpatch.update({'VAULT_TOKEN': 'fake'})
+
+        with mock.patch.dict(os.environ, envpatch):
+            with pytest.raises(ConnectionError) as e:
+                hashi_vault_lookup_module.run(['secret/fake'])
+
+        s_err = str(e)
+
+        assert host in s_err and str(port) in s_err, "host '%s' and port '%i' not found in exception: %r" % (host, port, e.value)

--- a/tests/unit/plugins/lookup/test_hashi_vault.py
+++ b/tests/unit/plugins/lookup/test_hashi_vault.py
@@ -46,12 +46,11 @@ class TestHashiVaultLookup(object):
         host = url.hostname
         port = url.port if url.port is not None else {'http': 80, 'https': 443}[url.scheme]
 
-        envpatch.update({'VAULT_TOKEN': 'fake'})
-
         with mock.patch.dict(os.environ, envpatch):
             with pytest.raises(ConnectionError) as e:
-                hashi_vault_lookup_module.run(['secret/fake'])
+                hashi_vault_lookup_module.run(['secret/fake'], token='fake')
 
-        s_err = str(e)
+        s_err = str(e.value)
 
-        assert host in s_err and str(port) in s_err, "host '%s' and port '%i' not found in exception: %r" % (host, port, e.value)
+        assert str(host) in s_err, "host '%s' not found in exception: %r" % (host, str(e.value))
+        assert str(port) in s_err, "port '%i' not found in exception: %r" % (port, str(e.value))


### PR DESCRIPTION
##### SUMMARY
Fixes #60

Related: 
- #49 
- #41 

When lowering the precedence of the `VAULT_ADDR` env var, I failed to take into account that the default value in the option itself would prevent the low pref env var value from ever being used, as implemented.

This would affect any option that has both a default value and a "low preference env var", which at the moment only applies to `url` / `VAULT_ADDR`.

This PR fixes that.

First, a unit test catching this is being added, then I will push a commit with the fix.

Note: the unit test only covers this option specifically and could be expanded. This work is actually already in progress in #59 , and I would have surfaced this eventually because of that. I'm keeping this small for this bugfix, but better tests will absolutely be introduced via the refactor.

## Affected Users
This bug will have affected version 1.0.0 and 1.1.0, since the env var priority change was released in 1.0.0 via #41 .

## Workarounds
The best workaround if possible is to switch to using `ANSIBLE_HASHI_VAULT_ADDR` or to set the address via `ansible.cfg`:
```ini
[lookup_hashi_vault]
url = https://myvault
```

If neither of those are possible, setting `url` explicitly on the plugin call can be done and the value can be read via the env lookup:

```yaml
- hosts: localhost
  vars:
    vaddr: "{{ lookup('env', 'VAULT_ADDR') }}"
  tasks:
    - debug:
        msg: "{{ lookup('community.hashi_vault.hashi_vault', 'secret=secret/whatever', url=vaddr) }}"
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hashi_vault.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
