### PR TITLE
hashi_vault - add support for `none` auth type

### DIFF
--- a/changelogs/fragments/80-add-none-auth-type.yml
+++ b/changelogs/fragments/80-add-none-auth-type.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - hashi_vault lookup - add ``none`` auth type which allows for passive auth via a Vault agent (https://github.com/ansible-collections/community.hashi_vault/pull/80).

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -147,7 +147,7 @@ DOCUMENTATION = """
         - approle
         - aws_iam_login
         - jwt
-        - agent
+        - none
       default: token
     return_format:
       description:
@@ -308,14 +308,14 @@ EXAMPLES = """
   ansible.builtin.debug:
     msg: "{{ lookup('community.hashi_vault.hashi_vault', 'secret/hello:value', token=my_token, token_validate=False) }}"
 
-# Agent auth
+# None auth
 
-# Vault Agent running with a TCP listener on port 8100.
+# For use with Vault Agent running with a TCP listener on port 8100.  Where the agent will handle authentication to Vault.
 # https://www.vaultproject.io/docs/agent
 
 - name: authenticate with vault agent
   ansible.builtin.debug:
-    msg: "{{ lookup('community.hashi_vault.hashi_vault', 'secret/hello:value', auth_method='agent', url='http://127.0.0.1:8100') }}"
+    msg: "{{ lookup('community.hashi_vault.hashi_vault', 'secret/hello:value', auth_method='none', url='http://127.0.0.1:8100') }}"
 
 # Use a proxy
 
@@ -570,7 +570,7 @@ class HashiVault:
         except (NotImplementedError, AttributeError):
             raise AnsibleError("JWT authentication requires HVAC version 0.10.5 or higher.")
 
-    def auth_agent(self):
+    def auth_none(self):
         pass
     # end auth implementation methods
 
@@ -642,7 +642,7 @@ class LookupModule(HashiVaultLookupBase):
     def auth_methods(self):
         # enforce and set the list of available auth methods
         # TODO: can this be read from the choices: field in documentation?
-        avail_auth_methods = ['token', 'approle', 'userpass', 'ldap', 'aws_iam_login', 'jwt', 'agent']
+        avail_auth_methods = ['token', 'approle', 'userpass', 'ldap', 'aws_iam_login', 'jwt', 'none']
         self.set_option('avail_auth_methods', avail_auth_methods)
         auth_method = self.get_option('auth_method')
 
@@ -737,6 +737,6 @@ class LookupModule(HashiVaultLookupBase):
     def validate_auth_jwt(self, auth_method):
         self.validate_by_required_fields(auth_method, 'role_id', 'jwt')
 
-    def validate_auth_agent(self, auth_method):
+    def validate_auth_none(self, auth_method):
         pass
     # end auth method validators

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -155,6 +155,7 @@ DOCUMENTATION = """
         - C(dict) returns a single dict containing the key/value pairs.
         - C(values) returns a list of all the values only. Use when you don't care about the keys.
         - C(raw) returns the actual API result (deserialized), which includes metadata and may have the data nested in other keys.
+        - C(none) auth method was added in collection version C(1.2.0).
       choices:
         - dict
         - values

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -315,7 +315,7 @@ EXAMPLES = """
 
 - name: authenticate with vault agent
   ansible.builtin.debug:
-    msg: "{{ lookup('community.hashi_vault.hashi_vault', 'secret/hello:value', auth_method=agent, url='http://127.0.0.1:8100') }}"
+    msg: "{{ lookup('community.hashi_vault.hashi_vault', 'secret/hello:value', auth_method='agent', url='http://127.0.0.1:8100') }}"
 
 # Use a proxy
 
@@ -512,7 +512,6 @@ class HashiVault:
     #    0.9.6 -- userpass
     #    0.10.5 -- jwt (new)
     #    0.10.6 -- approle
-    #    1.2.0 -- agent
     #
     def auth_token(self):
         if self.options['auth_method'] == 'token':

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -147,6 +147,7 @@ DOCUMENTATION = """
         - approle
         - aws_iam_login
         - jwt
+        - agent
       default: token
     return_format:
       description:
@@ -306,6 +307,15 @@ EXAMPLES = """
 - name: authenticate without token validation
   ansible.builtin.debug:
     msg: "{{ lookup('community.hashi_vault.hashi_vault', 'secret/hello:value', token=my_token, token_validate=False) }}"
+
+# Agent auth
+
+# Vault Agent running with a TCP listener on port 8100.
+# https://www.vaultproject.io/docs/agent
+
+- name: authenticate with vault agent
+  ansible.builtin.debug:
+    msg: "{{ lookup('community.hashi_vault.hashi_vault', 'secret/hello:value', auth_method=agent, url='http://127.0.0.1:8100') }}"
 
 # Use a proxy
 
@@ -560,6 +570,8 @@ class HashiVault:
         except (NotImplementedError, AttributeError):
             raise AnsibleError("JWT authentication requires HVAC version 0.10.5 or higher.")
 
+    def auth_agent(self):
+        pass
     # end auth implementation methods
 
 
@@ -630,7 +642,7 @@ class LookupModule(HashiVaultLookupBase):
     def auth_methods(self):
         # enforce and set the list of available auth methods
         # TODO: can this be read from the choices: field in documentation?
-        avail_auth_methods = ['token', 'approle', 'userpass', 'ldap', 'aws_iam_login', 'jwt']
+        avail_auth_methods = ['token', 'approle', 'userpass', 'ldap', 'aws_iam_login', 'jwt', 'agent']
         self.set_option('avail_auth_methods', avail_auth_methods)
         auth_method = self.get_option('auth_method')
 
@@ -725,4 +737,6 @@ class LookupModule(HashiVaultLookupBase):
     def validate_auth_jwt(self, auth_method):
         self.validate_by_required_fields(auth_method, 'role_id', 'jwt')
 
+    def validate_auth_agent(self, auth_method):
+        pass
     # end auth method validators

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -125,6 +125,7 @@ DOCUMENTATION = """
     auth_method:
       description:
         - Authentication method to be used.
+        - C(none) auth method was added in collection version C(1.2.0).
       env:
         - name: VAULT_AUTH_METHOD
           deprecated:
@@ -155,7 +156,6 @@ DOCUMENTATION = """
         - C(dict) returns a single dict containing the key/value pairs.
         - C(values) returns a list of all the values only. Use when you don't care about the keys.
         - C(raw) returns the actual API result (deserialized), which includes metadata and may have the data nested in other keys.
-        - C(none) auth method was added in collection version C(1.2.0).
       choices:
         - dict
         - values

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -512,6 +512,7 @@ class HashiVault:
     #    0.9.6 -- userpass
     #    0.10.5 -- jwt (new)
     #    0.10.6 -- approle
+    #    1.2.0 -- agent
     #
     def auth_token(self):
         if self.options['auth_method'] == 'token':

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -309,9 +309,8 @@ EXAMPLES = """
   ansible.builtin.debug:
     msg: "{{ lookup('community.hashi_vault.hashi_vault', 'secret/hello:value', token=my_token, token_validate=False) }}"
 
-# None auth
-
-# For use with Vault Agent running with a TCP listener on port 8100.  Where the agent will handle authentication to Vault.
+# "none" auth method does no authentication and does not send a token to the Vault address.
+# One example of where this could be used is with a Vault agent where the agent will handle authentication to Vault.
 # https://www.vaultproject.io/docs/agent
 
 - name: authenticate with vault agent

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/main.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/main.yml
@@ -24,6 +24,10 @@
 
 - import_tasks: tests.yml
   vars:
+    auth_type: none
+
+- import_tasks: tests.yml
+  vars:
     auth_type: token
 
 - name: approle tests

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/none_test.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/none_test.yml
@@ -1,0 +1,17 @@
+---
+# TODO: consider setting up a Vault agent in CI to provide a better test of the none method
+# TODO: unit tests can probably check easily that the none method results in a client with no token
+- name: "Test that a request with none auth_type is not successful"
+  vars:
+    ansible_hashi_vault_auth_method: none
+  debug:
+    msg: "{{ lookup('community.hashi_vault.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret1') }}"
+  register: status
+  ignore_errors: yes
+
+- name: "Assert failure of expected type"
+  assert:
+    that:
+      - status is failed
+      - status.msg is search('missing client token')
+        # msg may need updating over time


### PR DESCRIPTION
##### SUMMARY
Support the use of a locally running Vault Agent process to interact with Vault. This relieves the user almost entirely have need to manage or interact with tokens.

Fixes #79 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
community.hashi_vault, authentication methods.

##### ADDITIONAL INFORMATION

More details in: https://github.com/ansible-collections/community.hashi_vault/issues/79

```
- name: authenticate with vault agent
  ansible.builtin.debug:
    msg: "{{ lookup('community.hashi_vault.hashi_vault', 'secret/hello:value', auth_method=agent, url='http://127.0.0.1:8100') }}"
```

Also related, older issue against the main Ansible repo: https://github.com/ansible/ansible/issues/60728