### PR TITLE
Bunch of testing and README updates

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -146,7 +146,7 @@ jobs:
         include:
           - ansible: devel
             vault: 1.7.2
-            python: 3.10
+            python: '3.10'
 
     steps:
       - name: Initialize env vars

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -138,12 +138,15 @@ jobs:
           - 3.8
           - 3.9
         vault:
-          - 1.6.0
-          - 1.5.5
-          - 1.4.7
+          - 1.7.2
+          - 1.6.5
         exclude:
           - ansible: stable-2.9
             python: 3.9
+        include:
+          - ansible: devel
+            vault: 1.7.2
+            python: 3.10
 
     steps:
       - name: Initialize env vars

--- a/README.md
+++ b/README.md
@@ -6,14 +6,49 @@
 
 ## Tested with Ansible
 
+* 2.9
+* 2.10
+* 2.11
+* devel (latest development commit)
+
+See [the CI configuration](https://github.com/ansible-collections/community.hashi_vault/blob/main/.github/workflows/ansible-test.yml) for the most accurate testing information.
 <!-- List the versions of Ansible the collection has been tested with. Must match what is in galaxy.yml. -->
 
+## Tested with Vault
+
+We currently test against the latest two minor versions of Vault major version `1`. The patch version within each minor will be updated periodically.
+
+We do not test against any versions of Vault with major version `0`.
+
+If/when a new major version of Vault is released, we'll revisit which versions to test against.
+
+The decision of which version(s) of Vault to test against is still somewhat in flux, as we try to balance wide testing with CI execution time and resources.
+
+See [the CI configuration](https://github.com/ansible-collections/community.hashi_vault/blob/main/.github/workflows/ansible-test.yml) for the most accurate testing information.
+
+## Python Requirements
+
+**[Support for Python 2 will be dropped in `v2.0.0` of the collection.](https://github.com/ansible-collections/community.hashi_vault/issues/81)**
+
+Currently we test against Python versions:
+* 2.7
+* 3.5
+* 3.6
+* 3.7
+* 3.8
+* 3.9
+* 3.10 (support not yet guaranteed)
+
+
 ## External requirements
+
+**NOTE:** `hvac` versions `0.10.12` and `0.10.13` inadvertently did not work with Python 2.
 
   - `hvac` (python library)
     - `hvac` 0.7.0+ (for namespace support)
     - `hvac` 0.9.6+ (to avoid all deprecation warnings)
     - `hvac` 0.10.5+ (for JWT auth support)
+    - `hvac` 0.10.6+ (to avoid deprecation warning for AppRole)
   - `botocore` (only if inferring aws params from boto)
   - `boto3` (only if using a boto profile)
 

--- a/tests/integration/targets/lookup_hashi_vault/playbooks/install_dependencies.yml
+++ b/tests/integration/targets/lookup_hashi_vault/playbooks/install_dependencies.yml
@@ -1,19 +1,13 @@
 - hosts: localhost
+  vars:
+    remote_constraints: '{{ playbook_dir }}/../../../../utils/constraints.txt'
   tasks:
     - name: Install cryptography
       pip:
         name: cryptography
-
-    - name: "RedHat <= 7, select last version compatible with request 2.6.0 (this version doesn't support approle or jwt auth)"
-      set_fact:
-        hvac_package: 'hvac==0.2.5'
-      when: ansible_distribution == 'RedHat' and ansible_distribution_major_version is version('7', '<=')
-
-    - name: 'CentOS < 7, select last version compatible with Python 2.6'
-      set_fact:
-        hvac_package: 'hvac==0.5.0'
-      when: ansible_distribution == 'CentOS' and ansible_distribution_major_version is version('7', '<')
+        extra_args: '-c {{ remote_constraints }}'
 
     - name: 'Install hvac Python package'
       pip:
         name: "{{ hvac_package|default('hvac') }}"
+        extra_args: '-c {{ remote_constraints }}'

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,1 +1,2 @@
-hvac ; python_version >= '2.7'
+hvac >= 0.10.6, < 0.10.12 ; python_version == '2.7' # bugs in 0.10.12 and 0.10.13 prevent it from working in Python 2
+hvac >= 0.10.6 ; python_version >= '3.5'

--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -50,3 +50,7 @@ mccabe == 0.6.1
 pylint == 2.3.1
 typed-ast == 1.4.0  # 1.4.0 is required to compile on Python 3.8
 wrapt == 1.11.1
+
+# hvac
+hvac >= 0.10.6, < 0.10.12 ; python_version <= '2.7' # bugs in 0.10.12 and 0.10.13 prevent it from working in Python 2
+hvac >= 0.10.6 ; python_version >= '3.5'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Somewhat related: #81

With two releases of `hvac` broken on Py2 (inadvertently), I've started thinking it's time to drop Python2 support, hence the linked issue.

This PR started as trying to fix the tests to ensure they don't use the affected versions of `hvac`, some other changes went in.

### Testing
* `constraints.txt` and `requirements.txt` updated to stop at `hvac 0.10.11` in Python 2. As of this writing, `0.10.14` hasn't been released yet but it's expected it will restore Py2 compatibility. At that time I may change the constraints to exclude the two affected, and let it bring in newer ones, we'll see.
* The custom playbook for installing requirements in integration tests was not using the constraints file included in the collection. That has been changed.
* The requirements playbook's lines for choosing very old versions of `hvac` to work with old versions of OSes that are no longer tested against, have been removed.

### CI
* Reduced the number of Vault versions being tested against from 3 down to 2, and updated which versions to keep in line with newer Vault releases. The strain on CI was getting higher and it seems GitHub has reduced the available concurrency so CI runs were taking ever longer, especially considering the previous addition of Ansible 2.11 to the matrix.
* Added Python 3.10 testing, only in `devel` and only in the latest Vault version for now, in accordance with: https://github.com/ansible-collections/overview/issues/45#issuecomment-836847770

## Documentation
README updated to: 
* describe `hvac` requirements, add Py2 notice and link to issue
* better describe supported python versions
* better describe supported Ansible versions


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
