### PR TITLE
Allow hvac 0.10.14+

### DIFF
--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,2 +1,2 @@
-hvac >= 0.10.6, < 0.10.12 ; python_version == '2.7' # bugs in 0.10.12 and 0.10.13 prevent it from working in Python 2
+hvac >= 0.10.6, != 0.10.12, != 0.10.13 ; python_version == '2.7' # bugs in 0.10.12 and 0.10.13 prevent it from working in Python 2
 hvac >= 0.10.6 ; python_version >= '3.5'

--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -52,5 +52,5 @@ typed-ast == 1.4.0  # 1.4.0 is required to compile on Python 3.8
 wrapt == 1.11.1
 
 # hvac
-hvac >= 0.10.6, < 0.10.12 ; python_version <= '2.7' # bugs in 0.10.12 and 0.10.13 prevent it from working in Python 2
+hvac >= 0.10.6, != 0.10.12, != 0.10.13 ; python_version == '2.7' # bugs in 0.10.12 and 0.10.13 prevent it from working in Python 2
 hvac >= 0.10.6 ; python_version >= '3.5'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Related: #82 

`hvac 0.10.14` (https://github.com/hvac/hvac/releases/tag/v0.10.14) was released which fixes Python 2.7 support. This updates the requirements and restraints to exclude only the broken releases, so we can again test against later releases.

We'll have to be vigilant for future breakages in `hvac` before this collection's 2.0.0 release where we'll drop support for Py2 (see #81), and in the case of another breakage, be ready to update these files again.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
