### PR TITLE
Add ability to use ansible vars to specify options

### DIFF
--- a/changelogs/fragments/86-add-vars-options.yml
+++ b/changelogs/fragments/86-add-vars-options.yml
@@ -1,0 +1,10 @@
+---
+minor_changes:
+  - hashi_vault lookup - add ``ansible_hashi_vault_url`` and ``ansible_hashi_vault_addr`` Ansible vars entries to the ``url`` option (https://github.com/ansible-collections/community.hashi_vault/pull/86).
+  - hashi_vault lookup - add ``ansible_hashi_vault_proxies`` Ansible vars entry to the ``proxies`` option (https://github.com/ansible-collections/community.hashi_vault/pull/86).
+  - hashi_vault lookup - add ``ansible_hashi_vault_namespace`` Ansible vars entry to the ``namespace`` option (https://github.com/ansible-collections/community.hashi_vault/pull/86).
+  - hashi_vault lookup - add ``ansible_hashi_vault_token`` Ansible vars entry to the ``proxies`` option (https://github.com/ansible-collections/community.hashi_vault/pull/86).
+  - hashi_vault lookup - add ``ansible_hashi_vault_token_validate`` Ansible vars entry to the ``proxies`` option (https://github.com/ansible-collections/community.hashi_vault/pull/86).
+  - hashi_vault lookup - add ``ansible_hashi_vault_role_id`` Ansible vars entry to the ``proxies`` option (https://github.com/ansible-collections/community.hashi_vault/pull/86).
+  - hashi_vault lookup - add ``ansible_hashi_vault_secret_id`` Ansible vars entry to the ``proxies`` option (https://github.com/ansible-collections/community.hashi_vault/pull/86).
+  - hashi_vault lookup - add ``ansible_hashi_vault_auth_method`` Ansible vars entry to the ``proxies`` option (https://github.com/ansible-collections/community.hashi_vault/pull/86).

--- a/plugins/doc_fragments/connection.py
+++ b/plugins/doc_fragments/connection.py
@@ -22,6 +22,11 @@ class ModuleDocFragment(object):
         ini:
           - section: lookup_hashi_vault
             key: url
+        vars:
+          - name: ansible_hashi_vault_url
+            version_added: '1.2.0'
+          - name: ansible_hashi_vault_addr
+            version_added: '1.2.0'
       proxies:
         description:
           - URL(s) to the proxies used to access the Vault service.
@@ -36,6 +41,9 @@ class ModuleDocFragment(object):
         ini:
           - section: lookup_hashi_vault
             key: proxies
+        vars:
+          - name: ansible_hashi_vault_proxies
+            version_added: '1.2.0'
         type: raw
         version_added: '1.1.0'
       ca_cert:
@@ -60,4 +68,7 @@ class ModuleDocFragment(object):
           - section: lookup_hashi_vault
             key: namespace
             version_added: '0.2.0'
+        vars:
+          - name: ansible_hashi_vault_namespace
+            version_added: '1.2.0'
     '''

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/tests.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/tests.yml
@@ -8,78 +8,42 @@
   vars:
     conn_params: 'url=http://localhost:8200 proxies=http://127.0.0.1:8001 '
 
-- name: 'test {{ auth_type }} auth without SSL (environment variable)'
+- name: 'test {{ auth_type }} auth without SSL (ansible variable)'
   include_tasks: '{{ auth_type }}_test.yml'
   args:
     apply:
       vars:
         conn_params: ''
-      environment:
-        VAULT_ADDR: 'http://localhost:8200'
+        ansible_hashi_vault_url: 'http://localhost:8200'
 
-- when: cryptography_version.stdout is version('1.6', '>=')
-  block:
+- block:
     - name: 'test {{ auth_type }} auth with certs (validation enabled, lookup parameters)'
       include_tasks: '{{ auth_type }}_test.yml'
       vars:
         conn_params: 'url=https://localhost:8201 ca_cert={{ local_temp_dir }}/cert.pem validate_certs=True '
 
-    - name: 'test {{ auth_type }} auth with certs (validation enabled, lookup parameters, with dict proxy)'
+    - name: 'test {{ auth_type }} auth with certs (validation enabled, lookup parameters, with string proxy)'
       include_tasks: '{{ auth_type }}_test.yml'
       vars:
         conn_params: 'url=https://localhost:8201 ca_cert={{ local_temp_dir }}/cert.pem validate_certs=True proxies=https=http://127.0.0.1:8001 '
 
-    - name: 'test {{ auth_type }} auth with certs (validation enabled, environment variables)'
+    - name: 'test {{ auth_type }} auth with certs (validation enabled, lookup parameters, with dict proxy via ansible vars)'
+      include_tasks: '{{ auth_type }}_test.yml'
+      vars:
+        conn_params: 'url=https://localhost:8201 ca_cert={{ local_temp_dir }}/cert.pem validate_certs=True '
+        ansible_hashi_vault_proxies:
+          http: 'http://127.0.0.1:8001'
+          https: 'http://127.0.0.1:8001'
+
+    - name: 'test {{ auth_type }} auth with certs (validation enabled, ansible variables)'
       include_tasks: '{{ auth_type }}_test.yml'
       args:
         apply:
           vars:
-            conn_params: ''
-          environment:
-            VAULT_ADDR: 'https://localhost:8201'
-            VAULT_CACERT: '{{ local_temp_dir }}/cert.pem'
+            conn_params: 'ca_cert={{ local_temp_dir }}/cert.pem '
+            ansible_hashi_vault_addr: 'https://localhost:8201'
 
     - name: 'test {{ auth_type }} auth with certs (validation disabled, lookup parameters)'
       include_tasks: '{{ auth_type }}_test.yml'
       vars:
         conn_params: 'url=https://localhost:8201 validate_certs=False '
-
-    - name: 'test {{ auth_type }} auth with certs (validation using env VAR, lookup parameters)'
-      include_tasks: '{{ auth_type }}_test.yml'
-      args:
-        apply:
-          vars:
-            conn_params: ''
-          environment:
-            VAULT_ADDR: 'https://localhost:8201'
-            VAULT_SKIP_VERIFY: 1
-
-    - name: 'test {{ auth_type }} auth with certs (validation using env VAR (True), lookup parameters)'
-      include_tasks: '{{ auth_type }}_test.yml'
-      args:
-        apply:
-          vars:
-            conn_params: ''
-          environment:
-            VAULT_ADDR: 'https://localhost:8201'
-            VAULT_SKIP_VERIFY: True
-
-    - name: 'test {{ auth_type }} auth with certs (validation using env VAR (y), lookup parameters)'
-      include_tasks: '{{ auth_type }}_test.yml'
-      args:
-        apply:
-          vars:
-            conn_params: ''
-          environment:
-            VAULT_ADDR: 'https://localhost:8201'
-            VAULT_SKIP_VERIFY: y
-
-    - name: 'test {{ auth_type }} auth with certs (precedence of validate_certs over env VAR, lookup parameters)'
-      include_tasks: '{{ auth_type }}_test.yml'
-      args:
-        apply:
-          vars:
-            conn_params: 'validate_certs=False '
-          environment:
-            VAULT_ADDR: 'https://localhost:8201'
-            VAULT_SKIP_VERIFY: False

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_test.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_test.yml
@@ -1,16 +1,28 @@
 - name: "Test token with no default policy (missing lookup-self)"
   vars:
     user_token: '{{ user_token_no_default_policy_cmd.stdout }}'
-    lookup_terms: "{{ conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret1 auth_method=token token=' ~ user_token }}"
+    lookup_terms: "{{ conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret1' }}"
+    ansible_hashi_vault_auth_method: token
   block:
+    # task vars are not templated when used as vars, so we'll need to set_fact this evaluate the template
+    # see: https://github.com/ansible/ansible/issues/73268
+    - set_fact:
+        ansible_hashi_vault_token: '{{ user_token }}'
+
     - name: "Fetch a secret with no default policy token (failure expected)"
       debug:
         msg: "{{ lookup('community.hashi_vault.hashi_vault', lookup_terms) }}"
+      register: test_no_policy_failure
       ignore_errors: yes
 
+    - assert:
+        that: test_no_policy_failure is failed and test_no_policy_failure.msg is search('Invalid Hashicorp Vault Token')
+
     - name: "Fetch a secret with no default policy token - with no validation"
+      vars:
+        ansible_hashi_vault_token_validate: False
       debug:
-        msg: "{{ lookup('community.hashi_vault.hashi_vault', lookup_terms ~ ' token_validate=false') }}"
+        msg: "{{ lookup('community.hashi_vault.hashi_vault', lookup_terms) }}"
 
 - name: "Normal token tests"
   vars:
@@ -55,19 +67,19 @@
     - name: "Check multiple secrets as dict"
       fail:
         msg: 'Return value was not dict or items do not match.'
-      when: (kv2_secrets_as_dict | type_debug != 'dict') or (kv2_secrets_as_dict['value{{ item }}'] != 'foo{{ item }}')
+      when: (kv2_secrets_as_dict | type_debug != 'dict') or (kv2_secrets_as_dict['value' ~ item] != ('foo' ~ item))
       loop: [1, 2, 3]
 
     - name: "Check multiple secrets as values"
       fail:
         msg: 'Return value was not list or items do not match.'
-      when: (kv2_secrets_as_values | type_debug != 'list') or ('foo{{ item }}' not in kv2_secrets_as_values)
+      when: (kv2_secrets_as_values | type_debug != 'list') or (('foo' ~ item) not in kv2_secrets_as_values)
       loop: [1, 2, 3]
 
     - name: "Check multiple secrets as dict"
       fail:
         msg: 'Return value was not dict or items do not match.'
-      when: (kv2_secrets_as_dict | type_debug != 'dict') or (kv2_secrets_as_dict['value{{ item }}'] != 'foo{{ item }}')
+      when: (kv2_secrets_as_dict | type_debug != 'dict') or (kv2_secrets_as_dict['value' ~ item] != ('foo' ~ item))
       loop: [1, 2, 3]
 
     - name: 'Failure expected when erroneous credentials are used'
@@ -96,9 +108,10 @@
 
     - name: 'Failure expected when wrong proxy is used'
       vars:
-        secret_wrong_proxy: "{{ lookup('community.hashi_vault.hashi_vault', (conn_params|regex_replace('proxies=\\S*')) ~ 'proxies=' ~ (conn_params is search('url=https://') | ternary('https', 'http')) ~ '=http://127.0.0.1:4567 secret=' ~ vault_kv2_path ~ '/secret1 auth_method=token token=' ~ user_token) }}"
+        lookerup: "{{ (conn_params|regex_replace('proxies=\\S*')) ~ 'proxies=http://127.0.0.1:4567 secret=' ~ vault_kv2_path ~ '/secret1 auth_method=token token=' ~ user_token }}"
+        secret_wrong_proxy: "{{ lookup('community.hashi_vault.hashi_vault', lookerup) }}"
       debug:
-        msg: 'Failure is expected ({{secret_wrong_proxy}})'
+        msg: 'Failure is expected ({{secret_wrong_proxy}} -- {{ lookerup }})'
       register: test_wrong_proxy
       ignore_errors: true
 


### PR DESCRIPTION
##### SUMMARY
Fixes #49 
Fixes #65

<!--- Describe the change below, including rationale and design decisions -->
### The big change here is adding `vars:` entries for several options:
- `url ->`
  - `ansible_hashi_vault_url`
  - `ansible_hashi_vault_addr`
- `proxies -> ansible_hashi_vault_proxies`
- `namespace -> ansible_hashi_vault_namespace`
- `token -> ansible_hashi_vault_token`
- `token_validate -> ansible_hashi_vault_token_validate`
- `role_id -> ansible_hashi_vault_role_id`
- `secret_id -> ansible_hashi_vault_secret_id`
- `auth_method -> ansible_hashi_vault_auth_method`

Some new examples of usage:

```yaml
- name: use ansible vars to supply some options
  vars:
    ansible_hashi_vault_url: 'https://myvault:8282'
    ansible_hashi_vault_auth_method: token
  set_fact:
    secret1: "{{ lookup('secret/data/secret1') }}"
    secret2: "{{ lookup('secret/data/secret2') }}"

- name: use proxies with a dict (as direct ansible var)
  vars:
    ansible_hashi_vault_proxies:
      http: http://myproxy1
      https: https://myproxy2
  ansible.builtin.debug:
    msg: "{{ lookup('community.hashi_vault.hashi_vault', '...' }}"
```

## Important Note
Using templating in task vars **won't work** because of https://github.com/ansible/ansible/issues/73268 so this example **will fail**:
```yaml
- name: use ansible vars to supply some options
  vars:
    ansible_hashi_vault_url: '{{ my_other_url }}'
  debug:
    msg: "{{ lookup('secret/data/secret1') }}"
```

Instead, use `set_fact` to ensure your vars are evaluated beforehand.

```yaml
- set_fact:
    ansible_hashi_vault_url: '{{ my_other_url }}'

- name: use ansible vars to supply some options
  debug:
    msg: "{{ lookup('secret/data/secret1') }}"
```

### Other Changes
- There were many unnecessary test loops around the `validate_certs` option, checking different types of ways to specify yes/no, but they used environment variables via the `environment:` keyword which doesn't affect the lookup anyway. They have been removed, as unit tests now cover the various ways of supplying that option.
- Other test loops also erroneously used environment variables to set the Vault URL; that wasn't actually being used, it was actually using the default option value, so those would have broken after #83 . They have been replaced with ansible var equivalents.
- An additional proxy test loop was added that specified the `proxies` option as a dict via an ansible var.
- Templating in conditionals was removed to get rid of some warnings in the test output (#65).
- Removed a conditional about cryptography version that's not needed anymore.
- Other areas have been changed to use ansible vars to get more coverage on them or to simplify a test or both. I expect more replacements in the future to greatly cut down on the amount of string concatenation we're doing in the term string.
- A stronger evaluation of the token validation with no default policy expected failure test, by adding an assert to ensure the failure happens and with the message we expect.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hashi_vault

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
