### PR TITLE
tests - replace use of Vault CLI to configure the Vault server

### DIFF
--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/library/vault_ci_enable_auth.py
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/library/vault_ci_enable_auth.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 Brian Scholer (@briantist)
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+import hvac
+import re
+
+
+def main():
+    # corresponds to https://hvac.readthedocs.io/en/stable/usage/system_backend/auth.html#enable-auth-method
+    module = AnsibleModule(
+        argument_spec=dict(
+            url=dict(type='str', required=True),
+            token=dict(type='str', required=True),
+            method_type=dict(type='str', required=True),
+            path=dict(type='str'),
+            config=dict(type='dict'),
+            kwargs=dict(type='dict'),
+        ),
+    )
+
+    p = module.params
+
+    client = hvac.Client(url=p['url'], token=p['token'])
+
+    try:
+        client.sys.enable_auth_method(
+            method_type=p['method_type'],
+            path=p['path'],
+            config=p['config'],
+            kwargs=p['kwargs']
+        )
+
+    except hvac.exceptions.InvalidRequest as e:
+        if not str(e).startswith('path is already in use'):
+            raise
+
+        path = re.sub(r'^path is already in use at ([^/]+)/.*?$', r'\1', str(e))
+
+        methods = client.sys.list_auth_methods()['data']
+        if p['path'] and p['path'] != path:
+            raise
+
+        this_method = methods[path + '/']
+        if this_method['type'] != p['method_type']:
+            raise
+
+        module.warn("path in use ('%s'); retuning." % str(e))
+
+        client.sys.tune_auth_method(
+            path=path,
+            config=p['config'],
+            kwargs=p['kwargs']
+        )
+
+    module.exit_json(changed=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/library/vault_ci_enable_auth.py
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/library/vault_ci_enable_auth.py
@@ -32,7 +32,7 @@ def main():
             method_type=p['method_type'],
             path=p['path'],
             config=p['config'],
-            kwargs=p['kwargs']
+            kwargs=p['kwargs'],
         )
 
     except hvac.exceptions.InvalidRequest as e:
@@ -54,7 +54,7 @@ def main():
         client.sys.tune_auth_method(
             path=path,
             config=p['config'],
-            kwargs=p['kwargs']
+            kwargs=p['kwargs'],
         )
 
     module.exit_json(changed=True)

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/library/vault_ci_enable_engine.py
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/library/vault_ci_enable_engine.py
@@ -33,7 +33,7 @@ def main():
             path=p['path'],
             config=p['config'],
             options=p['options'],
-            kwargs=p['kwargs']
+            kwargs=p['kwargs'],
         )
 
     except hvac.exceptions.InvalidRequest as e:
@@ -51,7 +51,7 @@ def main():
             path=p['path'],
             config=p['config'],
             options=p['options'],
-            kwargs=p['kwargs']
+            kwargs=p['kwargs'],
         )
 
     module.exit_json(changed=True)

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/library/vault_ci_enable_engine.py
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/library/vault_ci_enable_engine.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 Brian Scholer (@briantist)
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+import hvac
+
+
+def main():
+    # corresponds to https://hvac.readthedocs.io/en/stable/usage/system_backend/mount.html#enable-secrets-engine
+    module = AnsibleModule(
+        argument_spec=dict(
+            url=dict(type='str', required=True),
+            token=dict(type='str', required=True),
+            backend_type=dict(type='str', required=True),
+            path=dict(type='str'),
+            config=dict(type='dict'),
+            options=dict(type='dict'),
+            kwargs=dict(type='dict'),
+        ),
+    )
+
+    p = module.params
+
+    client = hvac.Client(url=p['url'], token=p['token'])
+
+    try:
+        client.sys.enable_secrets_engine(
+            backend_type=p['backend_type'],
+            path=p['path'],
+            config=p['config'],
+            options=p['options'],
+            kwargs=p['kwargs']
+        )
+
+    except hvac.exceptions.InvalidRequest as e:
+        if not str(e).startswith('path is already in use'):
+            raise
+
+        engines = client.sys.list_mounted_secrets_engines()['data']
+        this_engine = engines[p['path'].strip('/') + '/']
+        if this_engine['type'] != p['backend_type']:
+            raise
+
+        module.warn("path '%s' of type '%s' already exists; retuning." % (p['path'], this_engine['type']))
+
+        client.sys.tune_mount_configuration(
+            path=p['path'],
+            config=p['config'],
+            options=p['options'],
+            kwargs=p['kwargs']
+        )
+
+    module.exit_json(changed=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/library/vault_ci_kv_put.py
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/library/vault_ci_kv_put.py
@@ -10,7 +10,6 @@ import hvac
 
 
 def main():
-    # corresponds to https://hvac.readthedocs.io/en/stable/usage/system_backend/mount.html#enable-secrets-engine
     module = AnsibleModule(
         argument_spec=dict(
             url=dict(type='str', required=True),

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/library/vault_ci_kv_put.py
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/library/vault_ci_kv_put.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 Brian Scholer (@briantist)
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+import hvac
+
+
+def main():
+    # corresponds to https://hvac.readthedocs.io/en/stable/usage/system_backend/mount.html#enable-secrets-engine
+    module = AnsibleModule(
+        argument_spec=dict(
+            url=dict(type='str', required=True),
+            token=dict(type='str', required=True),
+            path=dict(type='str'),
+            mount_point=dict(type='str'),
+            secret=dict(type='dict', required=True),
+            version=dict(type='int', default=2)
+        ),
+    )
+
+    p = module.params
+
+    client = hvac.Client(url=p['url'], token=p['token'])
+
+    client.secrets.kv.default_kv_version = p['version']
+
+    extra = {}
+    if p['mount_point'] is not None:
+        extra['mount_point'] = p['mount_point']
+
+    client.secrets.kv.create_or_update_secret(
+        path=p['path'],
+        secret=p['secret'],
+        **extra
+    )
+
+    module.exit_json(changed=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/library/vault_ci_policy_put.py
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/library/vault_ci_policy_put.py
@@ -25,7 +25,7 @@ def main():
 
     client.sys.create_or_update_policy(
         name=p['name'],
-        policy=p['policy']
+        policy=p['policy'],
     )
 
     module.exit_json(changed=True)

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/library/vault_ci_policy_put.py
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/library/vault_ci_policy_put.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 Brian Scholer (@briantist)
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+import hvac
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            url=dict(type='str', required=True),
+            token=dict(type='str', required=True),
+            name=dict(type='str', required=True),
+            policy=dict(type='raw', required=True),
+        ),
+    )
+
+    p = module.params
+
+    client = hvac.Client(url=p['url'], token=p['token'])
+
+    client.sys.create_or_update_policy(
+        name=p['name'],
+        policy=p['policy']
+    )
+
+    module.exit_json(changed=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/library/vault_ci_read.py
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/library/vault_ci_read.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 Brian Scholer (@briantist)
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+import hvac
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            url=dict(type='str', required=True),
+            token=dict(type='str', required=True),
+            path=dict(type='str', required=True),
+        ),
+    )
+
+    p = module.params
+
+    client = hvac.Client(url=p['url'], token=p['token'])
+
+    result = client.read(path=p['path'])
+
+    module.exit_json(changed=True, result=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/library/vault_ci_token_create.py
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/library/vault_ci_token_create.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 Brian Scholer (@briantist)
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+import hvac
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            url=dict(type='str', required=True),
+            token=dict(type='str', required=True),
+            no_default_policy=dict(type='bool', default=False),
+            policies=dict(type='str'),
+        ),
+    )
+
+    p = module.params
+
+    client = hvac.Client(url=p['url'], token=p['token'])
+
+    result = client.create_token(
+        policies=p['policies'],
+        no_default_policy=p.get('no_default_policy'),
+    )
+
+    module.exit_json(changed=True, result=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/library/vault_ci_write.py
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/library/vault_ci_write.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 Brian Scholer (@briantist)
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+from __future__ import absolute_import, division, print_function
+from typing import Mapping
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+import hvac
+import json
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            url=dict(type='str', required=True),
+            token=dict(type='str', required=True),
+            path=dict(type='str', required=True),
+            data=dict(type='dict', required=True),
+        ),
+    )
+
+    p = module.params
+
+    client = hvac.Client(url=p['url'], token=p['token'])
+
+    result = client.write(path=p['path'], **p['data'])
+
+    dictified = json.loads(
+        json.dumps(
+            result,
+            skipkeys=True,
+            default=lambda o: getattr(o, '__dict__', str(o)),
+        )
+    )
+
+    module.exit_json(changed=True, result=dictified)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/approle_secret_id_less_setup.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/approle_secret_id_less_setup.yml
@@ -1,19 +1,36 @@
 - name: 'Create an approle policy'
-  shell: "echo '{{ policy }}' | {{ vault_cmd }} policy write approle-policy-2 -"
-  vars:
+  vault_ci_policy_put:
+    url: "{{ vault_addr }}"
+    token: "{{ vault_dev_root_token_id }}"
+    name: approle-policy-2
     policy: |
       path "auth/approle/login" {
-       capabilities = [ "create", "read" ]
+        capabilities = [ "create", "read" ]
       }
 
 - name: 'Enable the AppRole auth method'
-  command: '{{ vault_cmd }} auth enable approle'
-  register: enable_approle
-  failed_when: "enable_approle.rc!=0 and 'path is already in use' not in enable_approle.stderr"
+  vault_ci_enable_auth:
+    url: "{{ vault_addr }}"
+    token: "{{ vault_dev_root_token_id }}"
+    method_type: approle
 
 - name: 'Create a named role without secret id'
-  command: '{{ vault_cmd }} write auth/approle/role/test-role-2 policies="test-policy,approle-policy-2" bind_secret_id=false secret_id_bound_cidrs="0.0.0.0/0"'
+  vault_ci_write:
+    url: "{{ vault_addr }}"
+    token: "{{ vault_dev_root_token_id }}"
+    path: 'auth/approle/role/test-role-2'
+    data:
+      policies: "test-policy,approle-policy-2"
+      bind_secret_id: False
+      secret_id_bound_cidrs: '0.0.0.0/0'
 
 - name: 'Fetch the RoleID of the AppRole'
-  command: '{{ vault_cmd }} read -field=role_id auth/approle/role/test-role-2/role-id'
+  vault_ci_read:
+    url: "{{ vault_addr }}"
+    token: "{{ vault_dev_root_token_id }}"
+    path: 'auth/approle/role/test-role-2/role-id'
   register: role_id_cmd_2
+
+- name: Register secret_id-less role ID
+  set_fact:
+    secret_id_less_role_id: '{{ role_id_cmd_2.result.data.role_id }}'

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/approle_secret_id_less_test.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/approle_secret_id_less_test.yml
@@ -1,5 +1,5 @@
 - vars:
-    role_id: '{{ role_id_cmd_2.stdout }}'
+    role_id: '{{ secret_id_less_role_id }}'
   block:
     - name: 'Fetch secrets using "hashi_vault" lookup'
       set_fact:

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/approle_setup.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/approle_setup.yml
@@ -4,30 +4,46 @@
     path_key: "{{ this_path | replace('-','_') }}"
   block:
     - name: 'Enable the AppRole auth method'
-      command: '{{ vault_cmd }} auth enable {{ "" if is_default_path else "-path " ~ this_path }} approle'
+      vault_ci_enable_auth:
+        url: "{{ vault_addr }}"
+        token: "{{ vault_dev_root_token_id }}"
+        method_type: approle
+        path: '{{ omit if is_default_path else this_path }}'
 
     - name: 'Create an approle policy'
-      command:
-        cmd: '{{ vault_cmd }} policy write approle-policy -'
-        stdin: |
+      vault_ci_policy_put:
+        url: "{{ vault_addr }}"
+        token: "{{ vault_dev_root_token_id }}"
+        name: approle-policy
+        policy: |
           path "auth/{{ this_path }}/login" {
           capabilities = [ "create", "read" ]
           }
 
     - name: 'Create a named role'
-      command: |-
-        {{ vault_cmd }} write auth/{{ this_path }}/role/test-role policies="{{ 'test-policy' if is_default_path else 'alt-policy' }},approle-policy"
+      vault_ci_write:
+        url: "{{ vault_addr }}"
+        token: "{{ vault_dev_root_token_id }}"
+        path: 'auth/{{ this_path }}/role/test-role'
+        data:
+          policies: "{{ 'test-policy' if is_default_path else 'alt-policy' }},approle-policy"
 
     - name: 'Fetch the RoleID of the AppRole'
-      command: '{{ vault_cmd }} read -field=role_id auth/{{ this_path }}/role/test-role/role-id'
+      vault_ci_read:
+        url: "{{ vault_addr }}"
+        token: "{{ vault_dev_root_token_id }}"
+        path: 'auth/{{ this_path }}/role/test-role/role-id'
       register: role_id_cmd
 
-
     - name: 'Get a SecretID issued against the AppRole'
-      command: '{{ vault_cmd }} write -field=secret_id -f auth/{{ this_path }}/role/test-role/secret-id'
+      vault_ci_write:
+        url: "{{ vault_addr }}"
+        token: "{{ vault_dev_root_token_id }}"
+        path: 'auth/{{ this_path }}/role/test-role/secret-id'
+        data: {}
       register: secret_id_cmd
 
     - name: register path-specific variables
       set_fact:
-        '{{ path_key }}_role_id': "{{ role_id_cmd.stdout }}"
-        '{{ path_key }}_secret_id': "{{ secret_id_cmd.stdout }}"
+        '{{ path_key }}_role_id': "{{ role_id_cmd.result.data.role_id }}"
+        '{{ path_key }}_secret_id': "{{ secret_id_cmd.result.data.secret_id }}"

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/jwt_setup.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/jwt_setup.yml
@@ -3,7 +3,11 @@
     is_default_path: "{{ this_path == default_path }}"
   block:
     - name: 'Enable the JWT auth method'
-      command: '{{ vault_cmd }} auth enable {{ "" if is_default_path else "-path " ~ this_path }} jwt'
+      vault_ci_enable_auth:
+        url: "{{ vault_addr }}"
+        token: "{{ vault_dev_root_token_id }}"
+        method_type: jwt
+        path: '{{ omit if is_default_path else this_path }}'
 
     - name: 'Configure the JWT auth method'
       command: '{{ vault_cmd }} write auth/{{ this_path }}/config jwt_validation_pubkeys={{ jwt_public_key | quote }}'

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/jwt_setup.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/jwt_setup.yml
@@ -10,17 +10,23 @@
         path: '{{ omit if is_default_path else this_path }}'
 
     - name: 'Configure the JWT auth method'
-      command: '{{ vault_cmd }} write auth/{{ this_path }}/config jwt_validation_pubkeys={{ jwt_public_key | quote }}'
       vars:
         jwt_public_key: '{{ lookup("file", "jwt_public.pem") }}'
+      vault_ci_write:
+        url: "{{ vault_addr }}"
+        token: "{{ vault_dev_root_token_id }}"
+        path: 'auth/{{ this_path }}/config'
+        data:
+          jwt_validation_pubkeys: '{{ jwt_public_key }}'
+          policies: "{{ 'test-policy' if is_default_path else 'alt-policy' }},approle-policy"
 
     - name: 'Create a named role'
-      command:
-        cmd: '{{ vault_cmd }} write auth/{{ this_path }}/role/test-role -'
-        stdin: |-
-          {
-            "role_type": "jwt",
-            "policies": "{{ 'test-policy' if is_default_path else 'alt-policy' }}",
-            "user_claim": "sub",
-            "bound_audiences": "test"
-          } | to_json
+      vault_ci_write:
+        url: "{{ vault_addr }}"
+        token: "{{ vault_dev_root_token_id }}"
+        path: 'auth/{{ this_path }}/role/test-role'
+        data:
+          role_type: jwt
+          policies: "{{ 'test-policy' if is_default_path else 'alt-policy' }},approle-policy"
+          user_claim: sub
+          bound_audiences: test

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_setup.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_setup.yml
@@ -1,7 +1,14 @@
 - name: 'Create a test credentials (token)'
-  command: '{{ vault_cmd }} token create -policy test-policy -field token'
+  vault_ci_token_create:
+    url: "{{ vault_addr }}"
+    token: "{{ vault_dev_root_token_id }}"
+    policies: test-policy
   register: user_token_cmd
 
 - name: 'Create a test credentials (token)'
-  command: '{{ vault_cmd }} token create -policy test-policy -field token -no-default-policy'
+  vault_ci_token_create:
+    url: "{{ vault_addr }}"
+    token: "{{ vault_dev_root_token_id }}"
+    policies: test-policy
+    no_default_policy: True
   register: user_token_no_default_policy_cmd

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_test.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_test.yml
@@ -1,6 +1,6 @@
 - name: "Test token with no default policy (missing lookup-self)"
   vars:
-    user_token: '{{ user_token_no_default_policy_cmd.stdout }}'
+    user_token: '{{ user_token_no_default_policy_cmd.result.auth.client_token }}'
     lookup_terms: "{{ conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret1' }}"
     ansible_hashi_vault_auth_method: token
   block:
@@ -26,7 +26,7 @@
 
 - name: "Normal token tests"
   vars:
-    user_token: '{{ user_token_cmd.stdout }}'
+    user_token: '{{ user_token_cmd.result.auth.client_token }}'
   block:
     - name: 'Fetch secrets using "hashi_vault" lookup'
       set_fact:

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/vault_server.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/vault_server.yml
@@ -94,22 +94,59 @@
                 stdin: '{{ vault_alt_policy }}'
 
             - name: 'Create generic secrets'
-              command: '{{ vault_cmd }} write {{ vault_gen_path }}/secret{{ item }} value=foo{{ item }}'
               loop: [1, 2, 3]
+              vault_ci_kv_put:
+                url: "{{ vault_addr }}"
+                token: "{{ vault_dev_root_token_id }}"
+                path: "{{ vault_gen_path | regex_replace('^gen/') }}/secret{{ item }}"
+                version: 1
+                mount_point: gen
+                secret:
+                  value: 'foo{{ item }}'
 
             - name: 'Create KV v1 secrets'
-              command: '{{ vault_cmd }} kv put {{ vault_kv1_path }}/secret{{ item }} value=foo{{ item }}'
               loop: [1, 2, 3]
+              vault_ci_kv_put:
+                url: "{{ vault_addr }}"
+                token: "{{ vault_dev_root_token_id }}"
+                path: "{{ vault_kv1_path | regex_replace('^kv1/') }}/secret{{ item }}"
+                version: 1
+                mount_point: kv1
+                secret:
+                  value: 'foo{{ item }}'
 
             - name: 'Create KV v2 secrets'
-              command: '{{ vault_cmd }} kv put {{ vault_kv2_path | regex_replace("/data") }}/secret{{ item }} value=foo{{ item }}'
               loop: [1, 2, 3, 4, 5]
+              vault_ci_kv_put:
+                url: "{{ vault_addr }}"
+                token: "{{ vault_dev_root_token_id }}"
+                path: "{{ vault_kv2_path | regex_replace('^kv2/data/') }}/secret{{ item }}"
+                version: 2
+                mount_point: kv2
+                secret:
+                  value: 'foo{{ item }}'
 
             - name: 'Update KV v2 secret4 with new value to create version'
-              command: '{{ vault_cmd }} kv put {{ vault_kv2_path | regex_replace("/data") }}/secret4 value=foo5'
+              vault_ci_kv_put:
+                url: "{{ vault_addr }}"
+                token: "{{ vault_dev_root_token_id }}"
+                path: "{{ vault_kv2_path | regex_replace('^kv2/data/') }}/secret4"
+                version: 2
+                mount_point: kv2
+                secret:
+                  value: 'foo5'
 
             - name: 'Create multiple KV v2 secrets under one path'
-              command: '{{ vault_cmd }} kv put {{ vault_kv2_multi_path | regex_replace("/data") }}/secrets value1=foo1 value2=foo2 value3=foo3'
+              vault_ci_kv_put:
+                url: "{{ vault_addr }}"
+                token: "{{ vault_dev_root_token_id }}"
+                path: "{{ vault_kv2_multi_path | regex_replace('^kv2/data/') }}/secrets"
+                version: 2
+                mount_point: kv2
+                secret:
+                  value1: foo1
+                  value2: foo2
+                  value3: foo3
 
             #### auth method setup
             - name: setup auth methods

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/vault_server.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/vault_server.yml
@@ -40,6 +40,8 @@
     - environment:
         # used by vault command
         VAULT_DEV_ROOT_TOKEN_ID: '47542cbc-6bf8-4fba-8eda-02e0a0d29a0a'
+      vars:
+        vault_dev_root_token_id: '47542cbc-6bf8-4fba-8eda-02e0a0d29a0a'
       block:
         - name: 'Create configuration file'
           template:
@@ -49,19 +51,37 @@
         - name: 'Start vault service'
           environment:
             VAULT_ADDR: 'http://localhost:8200'
+          vars:
+            vault_addr: 'http://localhost:8200'
           block:
             - name: 'Start vault server (dev mode enabled)'
               shell: 'nohup {{ vault_cmd }} server -dev -config {{ local_temp_dir }}/vault_config.hcl </dev/null >/dev/null 2>&1 &'
               notify: test_managed_vault_cleanup
 
             - name: 'Create generic secrets engine'
-              command: '{{ vault_cmd }} secrets enable -path=gen generic'
+              vault_ci_enable_engine:
+                url: "{{ vault_addr }}"
+                token: "{{ vault_dev_root_token_id }}"
+                backend_type: generic
+                path: gen
 
             - name: 'Create KV v1 secrets engine'
-              command: '{{ vault_cmd }} secrets enable -path=kv1 -version=1 kv'
+              vault_ci_enable_engine:
+                url: "{{ vault_addr }}"
+                token: "{{ vault_dev_root_token_id }}"
+                backend_type: kv
+                path: kv1
+                options:
+                  version: 1
 
             - name: 'Create KV v2 secrets engine'
-              command: '{{ vault_cmd }} secrets enable -path=kv2 -version=2 kv'
+              vault_ci_enable_engine:
+                url: "{{ vault_addr }}"
+                token: "{{ vault_dev_root_token_id }}"
+                backend_type: kv
+                path: kv2
+                options:
+                  version: 2
 
             - name: 'Create a test policy'
               command:

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/vault_server.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/vault_server.yml
@@ -84,14 +84,18 @@
                   version: 2
 
             - name: 'Create a test policy'
-              command:
-                cmd: '{{ vault_cmd }} policy write test-policy -'
-                stdin: '{{ vault_test_policy }}'
+              vault_ci_policy_put:
+                url: "{{ vault_addr }}"
+                token: "{{ vault_dev_root_token_id }}"
+                name: test-policy
+                policy: "{{ vault_test_policy }}"
 
             - name: 'Create an alternate policy'
-              command:
-                cmd: '{{ vault_cmd }} policy write alt-policy -'
-                stdin: '{{ vault_alt_policy }}'
+              vault_ci_policy_put:
+                url: "{{ vault_addr }}"
+                token: "{{ vault_dev_root_token_id }}"
+                name: alt-policy
+                policy: "{{ vault_alt_policy }}"
 
             - name: 'Create generic secrets'
               loop: [1, 2, 3]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds several modules for use within the integration tests, replacing use of the Vault CLI (Vault binary) to configure a running Vault server, with small Python modules that use `hvac` to communicate with the server instead.

This is an important step toward making the tests be able to run against a **configurable vault target server** without needing the Vault binary available.

This will unlock wider options for being able to run the Vault test server in a container, or use a pre-running server, etc.

It also makes it easier to separate out the Vault server configuration steps into their own `setup_` targets, which is going to help a lot with improving the way tests get run and invoked, which will make testing of new plugins and modules easier.

This PR doesn't do any of that yet (I have other PRs and local branches working on some of those things), getting this landed is the first step in moving those along.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
