### PR TITLE
tests - centralize vault addresses, better test control, split config vs. server start

### DIFF
--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/defaults/main.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/defaults/main.yml
@@ -85,9 +85,26 @@ vault_ansible_arch_table:
 
 vault_arch: "{{ vault_ansible_arch_table[ansible_architecture] }}"
 
-vault_version: '1.6.0'
+vault_version: '1.7.2'
 vault_bin: '{{ role_path }}/files/bin/{{ vault_slug }}'
 vault_slug: 'vault_{{ vault_version }}_{{ ansible_system | lower }}_{{ vault_arch }}'
 vault_zip: '{{ vault_bin }}/{{ vault_slug }}.zip'
 vault_uri: 'https://releases.hashicorp.com/vault/{{ vault_version }}/{{ vault_slug }}.zip'
 vault_cmd: '{{ vault_bin }}/vault'
+
+vault_dev_root_token_id: '47542cbc-6bf8-4fba-8eda-02e0a0d29a0a'
+vault_test_server_https: 'https://localhost:8201'
+vault_test_server_http: 'http://localhost:8200'
+
+# this means "don't download and start a Vault server", instead
+# just use the addresses above to connect to one that's already running
+vault_test_server_external: False
+
+# WIP
+vault_test_server_configure: True
+
+# when False the tests requiring a valid SSL connection to Vault will be skipped
+vault_run_https_tests: True
+
+vault_cert_file: '{{ local_temp_dir }}/cert.pem'
+vault_key_file: '{{ local_temp_dir }}/privatekey.pem'

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/approle_secret_id_less_setup.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/approle_secret_id_less_setup.yml
@@ -20,7 +20,10 @@
     token: "{{ vault_dev_root_token_id }}"
     path: 'auth/approle/role/test-role-2'
     data:
+      # in docs, this is token_policies (changed in Vault 1.2)
+      # use 'policies' to support older versions
       policies: "test-policy,approle-policy-2"
+      secret_id_ttl: 60m
       bind_secret_id: False
       secret_id_bound_cidrs: '0.0.0.0/0'
 

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/approle_setup.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/approle_setup.yml
@@ -26,7 +26,10 @@
         token: "{{ vault_dev_root_token_id }}"
         path: 'auth/{{ this_path }}/role/test-role'
         data:
+          # in docs, this is token_policies (changed in Vault 1.2)
+          # use 'policies' to support older versions
           policies: "{{ 'test-policy' if is_default_path else 'alt-policy' }},approle-policy"
+          secret_id_ttl: 60m
 
     - name: 'Fetch the RoleID of the AppRole'
       vault_ci_read:

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/jwt_setup.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/jwt_setup.yml
@@ -17,8 +17,10 @@
         token: "{{ vault_dev_root_token_id }}"
         path: 'auth/{{ this_path }}/config'
         data:
-          jwt_validation_pubkeys: '{{ jwt_public_key }}'
+          # in docs, this is token_policies (changed in Vault 1.2)
+          # use 'policies' to support older versions
           policies: "{{ 'test-policy' if is_default_path else 'alt-policy' }},approle-policy"
+          jwt_validation_pubkeys: '{{ jwt_public_key }}'
 
     - name: 'Create a named role'
       vault_ci_write:
@@ -26,7 +28,9 @@
         token: "{{ vault_dev_root_token_id }}"
         path: 'auth/{{ this_path }}/role/test-role'
         data:
-          role_type: jwt
+          # in docs, this is token_policies (changed in Vault 1.2)
+          # use 'policies' to support older versions
           policies: "{{ 'test-policy' if is_default_path else 'alt-policy' }},approle-policy"
+          role_type: jwt
           user_claim: sub
           bound_audiences: test

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/main.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/main.yml
@@ -13,7 +13,11 @@
 - set_fact:
     local_temp_dir: '{{ tempfile_result.path }}'
 
-- import_tasks: vault_server.yml
+- include_tasks: vault_server.yml
+  when: not vault_test_server_external | bool
+
+- import_tasks: vault_server_configure.yml
+  when: vault_test_server_configure | bool
 
 - import_tasks: tinyproxy_server.yml
 

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/tests.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/tests.yml
@@ -1,36 +1,47 @@
-- name: 'test {{ auth_type }} auth without SSL (lookup parameters)'
-  include_tasks: '{{ auth_type }}_test.yml'
+- name: HTTP connection
   vars:
-    conn_params: 'url=http://localhost:8200 '
+    conn_params: ''
+  block:
+    - name: Set the HTTP connection address
+      set_fact:
+        ansible_hashi_vault_url: '{{ vault_test_server_http }}'
 
-- name: 'test {{ auth_type }} auth without SSL (lookup parameters, with string proxy)'
-  include_tasks: '{{ auth_type }}_test.yml'
-  vars:
-    conn_params: 'url=http://localhost:8200 proxies=http://127.0.0.1:8001 '
+    - name: 'test {{ auth_type }} auth without SSL (lookup parameters)'
+      include_tasks: '{{ auth_type }}_test.yml'
 
-- name: 'test {{ auth_type }} auth without SSL (ansible variable)'
-  include_tasks: '{{ auth_type }}_test.yml'
-  args:
-    apply:
+    - name: 'test {{ auth_type }} auth without SSL (lookup parameters, with string proxy)'
+      include_tasks: '{{ auth_type }}_test.yml'
       vars:
-        conn_params: ''
-        ansible_hashi_vault_url: 'http://localhost:8200'
+        conn_params: 'proxies=http://127.0.0.1:8001 '
 
-- block:
+    - name: 'test {{ auth_type }} auth without SSL (ansible variable)'
+      include_tasks: '{{ auth_type }}_test.yml'
+      args:
+        apply:
+          vars:
+            conn_params: ''
+
+- name: HTTPS connection
+  when: vault_run_https_tests | bool
+  block:
+    - name: Set the HTTPS connection address
+      set_fact:
+        ansible_hashi_vault_url: '{{ vault_test_server_https }}'
+
     - name: 'test {{ auth_type }} auth with certs (validation enabled, lookup parameters)'
       include_tasks: '{{ auth_type }}_test.yml'
       vars:
-        conn_params: 'url=https://localhost:8201 ca_cert={{ local_temp_dir }}/cert.pem validate_certs=True '
+        conn_params: 'ca_cert={{ vault_cert_file }} validate_certs=True '
 
     - name: 'test {{ auth_type }} auth with certs (validation enabled, lookup parameters, with string proxy)'
       include_tasks: '{{ auth_type }}_test.yml'
       vars:
-        conn_params: 'url=https://localhost:8201 ca_cert={{ local_temp_dir }}/cert.pem validate_certs=True proxies=https=http://127.0.0.1:8001 '
+        conn_params: 'ca_cert={{ vault_cert_file }} validate_certs=True proxies=https=http://127.0.0.1:8001 '
 
     - name: 'test {{ auth_type }} auth with certs (validation enabled, lookup parameters, with dict proxy via ansible vars)'
       include_tasks: '{{ auth_type }}_test.yml'
       vars:
-        conn_params: 'url=https://localhost:8201 ca_cert={{ local_temp_dir }}/cert.pem validate_certs=True '
+        conn_params: 'url={{ vault_test_server_https }} ca_cert={{ vault_cert_file }} validate_certs=True '
         ansible_hashi_vault_proxies:
           http: 'http://127.0.0.1:8001'
           https: 'http://127.0.0.1:8001'
@@ -40,10 +51,9 @@
       args:
         apply:
           vars:
-            conn_params: 'ca_cert={{ local_temp_dir }}/cert.pem '
-            ansible_hashi_vault_addr: 'https://localhost:8201'
+            conn_params: 'ca_cert={{ vault_cert_file }} '
 
     - name: 'test {{ auth_type }} auth with certs (validation disabled, lookup parameters)'
       include_tasks: '{{ auth_type }}_test.yml'
       vars:
-        conn_params: 'url=https://localhost:8201 validate_certs=False '
+        conn_params: 'validate_certs=False '

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_setup.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_setup.yml
@@ -1,11 +1,12 @@
-- name: 'Create a test credentials (token)'
+---
+- name: 'Create a test token non-root token'
   vault_ci_token_create:
     url: "{{ vault_addr }}"
     token: "{{ vault_dev_root_token_id }}"
     policies: test-policy
   register: user_token_cmd
 
-- name: 'Create a test credentials (token)'
+- name: 'Create a test non-root token with no default policy'
   vault_ci_token_create:
     url: "{{ vault_addr }}"
     token: "{{ vault_dev_root_token_id }}"

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/vault_server.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/vault_server.yml
@@ -2,24 +2,26 @@
 - name: Install Hashi Vault on controlled node and test
   block:
 
-    - when: cryptography_version.stdout is version('1.6', '>=')
+    - when: vault_run_https_tests | bool
+      vars:
+        vault_csr_file: '{{ vault_key_file | dirname }}/csr.csr'
       block:
         - name: Generate privatekey
           community.crypto.openssl_privatekey:
-            path: '{{ local_temp_dir }}/privatekey.pem'
+            path: '{{ vault_key_file }}'
 
         - name: Generate CSR
           community.crypto.openssl_csr:
-            path: '{{ local_temp_dir }}/csr.csr'
-            privatekey_path: '{{ local_temp_dir }}/privatekey.pem'
+            path: '{{ vault_csr_file }}'
+            privatekey_path: '{{ vault_key_file }}'
             subject:
               commonName: localhost
 
         - name: Generate selfsigned certificate
           community.crypto.openssl_certificate:
-            path: '{{ local_temp_dir }}/cert.pem'
-            csr_path: '{{ local_temp_dir }}/csr.csr'
-            privatekey_path: '{{ local_temp_dir }}/privatekey.pem'
+            path: '{{ vault_cert_file }}'
+            csr_path: '{{ vault_csr_file }}'
+            privatekey_path: '{{ vault_key_file }}'
             provider: selfsigned
             selfsigned_digest: sha256
           register: selfsigned_certificate
@@ -39,119 +41,13 @@
 
     - environment:
         # used by vault command
-        VAULT_DEV_ROOT_TOKEN_ID: '47542cbc-6bf8-4fba-8eda-02e0a0d29a0a'
-      vars:
-        vault_dev_root_token_id: '47542cbc-6bf8-4fba-8eda-02e0a0d29a0a'
+        VAULT_DEV_ROOT_TOKEN_ID: '{{ vault_dev_root_token_id }}'
       block:
         - name: 'Create configuration file'
           template:
             src: vault_config.hcl.j2
             dest: '{{ local_temp_dir }}/vault_config.hcl'
 
-        - name: 'Start vault service'
-          environment:
-            VAULT_ADDR: 'http://localhost:8200'
-          vars:
-            vault_addr: 'http://localhost:8200'
-          block:
-            - name: 'Start vault server (dev mode enabled)'
-              shell: 'nohup {{ vault_cmd }} server -dev -config {{ local_temp_dir }}/vault_config.hcl </dev/null >/dev/null 2>&1 &'
-              notify: test_managed_vault_cleanup
-
-            - name: 'Create generic secrets engine'
-              vault_ci_enable_engine:
-                url: "{{ vault_addr }}"
-                token: "{{ vault_dev_root_token_id }}"
-                backend_type: generic
-                path: gen
-
-            - name: 'Create KV v1 secrets engine'
-              vault_ci_enable_engine:
-                url: "{{ vault_addr }}"
-                token: "{{ vault_dev_root_token_id }}"
-                backend_type: kv
-                path: kv1
-                options:
-                  version: 1
-
-            - name: 'Create KV v2 secrets engine'
-              vault_ci_enable_engine:
-                url: "{{ vault_addr }}"
-                token: "{{ vault_dev_root_token_id }}"
-                backend_type: kv
-                path: kv2
-                options:
-                  version: 2
-
-            - name: 'Create a test policy'
-              vault_ci_policy_put:
-                url: "{{ vault_addr }}"
-                token: "{{ vault_dev_root_token_id }}"
-                name: test-policy
-                policy: "{{ vault_test_policy }}"
-
-            - name: 'Create an alternate policy'
-              vault_ci_policy_put:
-                url: "{{ vault_addr }}"
-                token: "{{ vault_dev_root_token_id }}"
-                name: alt-policy
-                policy: "{{ vault_alt_policy }}"
-
-            - name: 'Create generic secrets'
-              loop: [1, 2, 3]
-              vault_ci_kv_put:
-                url: "{{ vault_addr }}"
-                token: "{{ vault_dev_root_token_id }}"
-                path: "{{ vault_gen_path | regex_replace('^gen/') }}/secret{{ item }}"
-                version: 1
-                mount_point: gen
-                secret:
-                  value: 'foo{{ item }}'
-
-            - name: 'Create KV v1 secrets'
-              loop: [1, 2, 3]
-              vault_ci_kv_put:
-                url: "{{ vault_addr }}"
-                token: "{{ vault_dev_root_token_id }}"
-                path: "{{ vault_kv1_path | regex_replace('^kv1/') }}/secret{{ item }}"
-                version: 1
-                mount_point: kv1
-                secret:
-                  value: 'foo{{ item }}'
-
-            - name: 'Create KV v2 secrets'
-              loop: [1, 2, 3, 4, 5]
-              vault_ci_kv_put:
-                url: "{{ vault_addr }}"
-                token: "{{ vault_dev_root_token_id }}"
-                path: "{{ vault_kv2_path | regex_replace('^kv2/data/') }}/secret{{ item }}"
-                version: 2
-                mount_point: kv2
-                secret:
-                  value: 'foo{{ item }}'
-
-            - name: 'Update KV v2 secret4 with new value to create version'
-              vault_ci_kv_put:
-                url: "{{ vault_addr }}"
-                token: "{{ vault_dev_root_token_id }}"
-                path: "{{ vault_kv2_path | regex_replace('^kv2/data/') }}/secret4"
-                version: 2
-                mount_point: kv2
-                secret:
-                  value: 'foo5'
-
-            - name: 'Create multiple KV v2 secrets under one path'
-              vault_ci_kv_put:
-                url: "{{ vault_addr }}"
-                token: "{{ vault_dev_root_token_id }}"
-                path: "{{ vault_kv2_multi_path | regex_replace('^kv2/data/') }}/secrets"
-                version: 2
-                mount_point: kv2
-                secret:
-                  value1: foo1
-                  value2: foo2
-                  value3: foo3
-
-            #### auth method setup
-            - name: setup auth methods
-              import_tasks: vault_server_auth_setup.yml
+        - name: 'Start vault server (dev mode enabled)'
+          shell: 'nohup {{ vault_cmd }} server -dev -config {{ local_temp_dir }}/vault_config.hcl </dev/null >/dev/null 2>&1 &'
+          notify: test_managed_vault_cleanup

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/vault_server_configure.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/vault_server_configure.yml
@@ -1,0 +1,102 @@
+---
+- name: Configuration tasks
+  vars:
+    vault_addr: '{{ vault_test_server_http }}'
+  block:
+    - name: 'Create generic secrets engine'
+      vault_ci_enable_engine:
+        url: "{{ vault_addr }}"
+        token: "{{ vault_dev_root_token_id }}"
+        backend_type: generic
+        path: gen
+
+    - name: 'Create KV v1 secrets engine'
+      vault_ci_enable_engine:
+        url: "{{ vault_addr }}"
+        token: "{{ vault_dev_root_token_id }}"
+        backend_type: kv
+        path: kv1
+        options:
+          version: 1
+
+    - name: 'Create KV v2 secrets engine'
+      vault_ci_enable_engine:
+        url: "{{ vault_addr }}"
+        token: "{{ vault_dev_root_token_id }}"
+        backend_type: kv
+        path: kv2
+        options:
+          version: 2
+
+    - name: 'Create a test policy'
+      vault_ci_policy_put:
+        url: "{{ vault_addr }}"
+        token: "{{ vault_dev_root_token_id }}"
+        name: test-policy
+        policy: "{{ vault_test_policy }}"
+
+    - name: 'Create an alternate policy'
+      vault_ci_policy_put:
+        url: "{{ vault_addr }}"
+        token: "{{ vault_dev_root_token_id }}"
+        name: alt-policy
+        policy: "{{ vault_alt_policy }}"
+
+    - name: 'Create generic secrets'
+      loop: [1, 2, 3]
+      vault_ci_kv_put:
+        url: "{{ vault_addr }}"
+        token: "{{ vault_dev_root_token_id }}"
+        path: "{{ vault_gen_path | regex_replace('^gen/') }}/secret{{ item }}"
+        version: 1
+        mount_point: gen
+        secret:
+          value: 'foo{{ item }}'
+
+    - name: 'Create KV v1 secrets'
+      loop: [1, 2, 3]
+      vault_ci_kv_put:
+        url: "{{ vault_addr }}"
+        token: "{{ vault_dev_root_token_id }}"
+        path: "{{ vault_kv1_path | regex_replace('^kv1/') }}/secret{{ item }}"
+        version: 1
+        mount_point: kv1
+        secret:
+          value: 'foo{{ item }}'
+
+    - name: 'Create KV v2 secrets'
+      loop: [1, 2, 3, 4, 5]
+      vault_ci_kv_put:
+        url: "{{ vault_addr }}"
+        token: "{{ vault_dev_root_token_id }}"
+        path: "{{ vault_kv2_path | regex_replace('^kv2/data/') }}/secret{{ item }}"
+        version: 2
+        mount_point: kv2
+        secret:
+          value: 'foo{{ item }}'
+
+    - name: 'Update KV v2 secret4 with new value to create version'
+      vault_ci_kv_put:
+        url: "{{ vault_addr }}"
+        token: "{{ vault_dev_root_token_id }}"
+        path: "{{ vault_kv2_path | regex_replace('^kv2/data/') }}/secret4"
+        version: 2
+        mount_point: kv2
+        secret:
+          value: 'foo5'
+
+    - name: 'Create multiple KV v2 secrets under one path'
+      vault_ci_kv_put:
+        url: "{{ vault_addr }}"
+        token: "{{ vault_dev_root_token_id }}"
+        path: "{{ vault_kv2_multi_path | regex_replace('^kv2/data/') }}/secrets"
+        version: 2
+        mount_point: kv2
+        secret:
+          value1: foo1
+          value2: foo2
+          value3: foo3
+
+    #### auth method setup
+    - name: setup auth methods
+      import_tasks: vault_server_auth_setup.yml

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/templates/vault_config.hcl.j2
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/templates/vault_config.hcl.j2
@@ -1,10 +1,10 @@
 # {{ ansible_managed }}
 pid_file = "{{ local_temp_dir }}/vault.pid"
-{% if cryptography_version.stdout is version('1.6', '>=') %}
+{% if vault_run_https_tests | bool %}
 listener "tcp" {
-  tls_key_file = "{{ local_temp_dir }}/privatekey.pem"
-  tls_cert_file = "{{ local_temp_dir }}/cert.pem"
+  tls_key_file = "{{ vault_key_file }}"
+  tls_cert_file = "{{ vault_cert_file }}"
   tls_disable  = false
-  address = "localhost:8201"
+  address = "{{ vault_test_server_https | regex_replace('^https://([^:]+):(\\d+).*?$', '\\1:\\2') }}"
 }
 {% endif %}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
More test improvements following on #88 

* The addresses of the vault server are now centralized into variables instead of being duplicated and spread throughout the test files. This will make it easier to specify an externally running Vault server to run tests against, furthering the separation between server prep and tests against it.
* Other variables related to configuring or starting a Vault server also moved centrally.
* The Vault server setup is now split between the acts of downloading and starting a local Vault server vs. running commands against the running Vault server (setting up backends, secrets, auth methods, etc.). Another change toward supporting a running Vault server that wasn't started by the test suite itself.
* Vault HTTP and HTTPS tests are more clearly separated and the HTTPS tests can be optionally skipped entirely by setting a single variable. This will make for easier local setup of an external Vault server (like in a container) for those who are doing development and running tests locally, but almost certainly don't need to run the HTTPS tests.
* The cert/key file locations for HTTPS vault are now located centrally in variables as well, so that they aren't strewn about.
* While these are being pushed into the one `defaults/main.yml` file for now, the real point of this is to be able to move these operations into their own roles, so that those operations are more discrete. In addition, when we remove the need for `runme.sh` and have more traditional role-based tests, we can use the `.gitignore`d `integration_config.yml` to control these values in different testing scenarios.
* Some minor updates, like comments, text fixes, etc.

### Things still to do and things learned
(these are musings mostly to remind myself)

* doing HTTPS tests against an external vault server is tricky. It needed to be set up to listen with TLS, which means it needed a cert, and then for the tests to test name matching functionality, the tests need to connect to that Vault instance with a name that matches the cert; further if the cert was self-signed, we need a copy of the cert to use as a "ca" file so that the cert "chain" can be verified.
* Mid-term, since the connection parameters have been moved to central code, I'd like to test connection stuff with its own set of integration tests, and not re-run every auth test x every connection test, as it will greatly reduce the number of tests needed to be run. But this doesn't solve the stickiness with setting up the Vault server.
* It gets easier if we don't "test" name validation from end to end, which may be for the best: the part we actually care about is that the Ansible content correctly sends the options to `hvac`, from there what happens between `hvac` and a Vault server is largely out of our hands. That would make for a test that can be done much more easily within unit tests. There is a possibility of uncaught bugs/regressions in `hvac` (or even Vault) and it would be nice to catch those early in case they can be worked around but I'll have to consider whether that's worth the complexity. A middle ground might be integration tests for TLS and cert verification that have `hvac` talking to an httptester (the requests will fail but it should be detectable that the failures are related to not talking to a Vault server, as they will have "passed" the point of failing for TLS-related reasons).
* Apart from the above, when running tests locally it'll be nice to skip all of those redundant tests since most work being done will not be touching that, and the TLS tests will still run in CI.
* We have a test for ensuring that retrieval of a secret version works, but this is done by manually adding a query string to your secret path; it's not really a documented feature of the plugin. This relies on adding a second version of a secret during Vault server configuration. As I was testing I ran into the issue that with an externally running Vault server, re-running the configuration over and over (which now works without failure after #88), eventually causes that secret to hit its version limit, and version 2 of the secret (which is the hardcoded version in the tests), no longer exists. So I need to think about whether this test is actually needed/useful at all (I'm leaning no, we make no guarantee that will work), and if it is, need to complicate the secret setup a bit to ensure that there's always a version 2, or complicate the test to determine a valid version number.
* There are some tests where data retrieved during the configuration stage needs to get used in the testing stage: for example, tokens are created for the token tests, AppRole auth method generates a new approle and secret ID for use in their tests. I have a flag to skip the configuration altogether (useful when your external server has already been set up and you wanna save a little speed by skipping the unnecessary configuration), but then those tests fail because they don't have the info they need anymore.
* The token one can be fixed by moving those two tasks (the only setup tasks for token) into the test part themselves: they are runtime actions after all.. even though they do create a Vault object.
* For AppRole, we can change from using generated IDs, to telling Vault the AppRole ID and Secret ID we want (I think), even though that's unusual. That would let us hardcode those IDs, create them in the configuration phase, and know them a priori in the test phase so other runs won't fail.
* But I want to think a little more about how to best handle these, and whether to further splinter the setup/configuration type tasks into a one-time / each-time sort of paradigm (or to just push everything of that nature into the test phase.. which was my first inclination but it felt wrong looking at approle, where we'd need to not only create the approle, but also assign policies and such).

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
