### PR TITLE
tests - allow for external proxy

### DIFF
--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/defaults/main.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/defaults/main.yml
@@ -108,3 +108,6 @@ vault_run_https_tests: True
 
 vault_cert_file: '{{ local_temp_dir }}/cert.pem'
 vault_key_file: '{{ local_temp_dir }}/privatekey.pem'
+
+vault_proxy_server: 'http://127.0.0.1:8001'
+vault_proxy_external: False

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/main.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/main.yml
@@ -19,7 +19,8 @@
 - import_tasks: vault_server_configure.yml
   when: vault_test_server_configure | bool
 
-- import_tasks: tinyproxy_server.yml
+- include_tasks: tinyproxy_server.yml
+  when: not vault_proxy_external | bool
 
 - import_tasks: tests.yml
   vars:

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/tests.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/tests.yml
@@ -12,7 +12,7 @@
     - name: 'test {{ auth_type }} auth without SSL (lookup parameters, with string proxy)'
       include_tasks: '{{ auth_type }}_test.yml'
       vars:
-        conn_params: 'proxies=http://127.0.0.1:8001 '
+        conn_params: 'proxies={{ vault_proxy_server }} '
 
     - name: 'test {{ auth_type }} auth without SSL (ansible variable)'
       include_tasks: '{{ auth_type }}_test.yml'
@@ -36,15 +36,22 @@
     - name: 'test {{ auth_type }} auth with certs (validation enabled, lookup parameters, with string proxy)'
       include_tasks: '{{ auth_type }}_test.yml'
       vars:
-        conn_params: 'ca_cert={{ vault_cert_file }} validate_certs=True proxies=https=http://127.0.0.1:8001 '
+        conn_params: 'ca_cert={{ vault_cert_file }} validate_certs=True proxies={{ vault_proxy_server }} '
+
+    - name: Set proxies variable
+      set_fact:
+        ansible_hashi_vault_proxies:
+          http: '{{ vault_proxy_server }}'
+          https: '{{ vault_proxy_server }}'
 
     - name: 'test {{ auth_type }} auth with certs (validation enabled, lookup parameters, with dict proxy via ansible vars)'
       include_tasks: '{{ auth_type }}_test.yml'
       vars:
         conn_params: 'url={{ vault_test_server_https }} ca_cert={{ vault_cert_file }} validate_certs=True '
-        ansible_hashi_vault_proxies:
-          http: 'http://127.0.0.1:8001'
-          https: 'http://127.0.0.1:8001'
+
+    - name: Reset proxies variable
+      set_fact:
+        ansible_hashi_vault_proxies: null
 
     - name: 'test {{ auth_type }} auth with certs (validation enabled, ansible variables)'
       include_tasks: '{{ auth_type }}_test.yml'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Building on #88 and #90 , this PR removed the duplicated proxy address references, and sets up the tests for working with an external tinyproxy (really any proxy I guess) rather than having the tests install and manage one.

It doesn't change the CI to use an external proxy in a container yet even though it could, because we're not yet able to use Vault in an external container, and the proxy can't reach Vault running in the test container ☹ as we have no way to address the container managed by `ansible-test` through name or IP.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
