### PR TITLE
add more vars options (token path, token file, validate certs)

### DIFF
--- a/changelogs/fragments/95-more-vars-options.yml
+++ b/changelogs/fragments/95-more-vars-options.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - hashi_vault lookup - add ``ansible_hashi_vault_token_path`` Ansible vars entry to the ``token_path`` option (https://github.com/ansible-collections/community.hashi_vault/pull/95).
+  - hashi_vault lookup - add ``ansible_hashi_vault_token_file`` Ansible vars entry to the ``token_file`` option (https://github.com/ansible-collections/community.hashi_vault/pull/95).
+  - hashi_vault lookup - add ``ansible_hashi_vault_validate_certs`` Ansible vars entry to the ``validate_certs`` option (https://github.com/ansible-collections/community.hashi_vault/pull/95).

--- a/plugins/doc_fragments/connection.py
+++ b/plugins/doc_fragments/connection.py
@@ -55,6 +55,9 @@ class ModuleDocFragment(object):
           - Will be populated with the inverse of C(VAULT_SKIP_VERIFY) if that is set and I(validate_certs) is not explicitly provided.
           - Will default to C(true) if neither I(validate_certs) or C(VAULT_SKIP_VERIFY) are set.
         type: boolean
+        vars:
+          - name: ansible_hashi_vault_validate_certs
+            version_added: '1.2.0'
       namespace:
         description:
           - Vault namespace where secrets reside. This option requires HVAC 0.7.0+ and Vault 0.11+.

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -57,6 +57,9 @@ DOCUMENTATION = """
       ini:
         - section: lookup_hashi_vault
           key: token_path
+      vars:
+        - name: ansible_hashi_vault_token_path
+          version_added: '1.2.0'
     token_file:
       description: If no token is specified, will try to read the token from this file in I(token_path).
       env:
@@ -71,6 +74,9 @@ DOCUMENTATION = """
       ini:
         - section: lookup_hashi_vault
           key: token_file
+      vars:
+        - name: ansible_hashi_vault_token_file
+          version_added: '1.2.0'
       default: '.vault-token'
     token_validate:
       description:

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/tests.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/tests.yml
@@ -63,4 +63,5 @@
     - name: 'test {{ auth_type }} auth with certs (validation disabled, lookup parameters)'
       include_tasks: '{{ auth_type }}_test.yml'
       vars:
-        conn_params: 'validate_certs=False '
+        ansible_hashi_vault_validate_certs: False
+        conn_params: ''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes: #94 
Related: #86 

Adds:
- `ansible_hashi_vault_token_path` and `ansible_hashi_vault_token_file` as requested in #94
- `ansible_hashi_vault_validate_certs`

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hashi_vault.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
