### PR TITLE
hashi_vault - add env and vars for userpass options

### DIFF
--- a/changelogs/fragments/96-userpass-vars-env.yml
+++ b/changelogs/fragments/96-userpass-vars-env.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - hashi_vault - add ``ANSIBLE_HASHI_VAULT_USERNAME`` env var and ``ansible_hashi_vault_username`` ansible var for ``username`` option (https://github.com/ansible-collections/community.hashi_vault/pull/96).
+  - hashi_vault - add ``ANSIBLE_HASHI_VAULT_PASSWORD`` env var and ``ansible_hashi_vault_password`` ansible var for ``password`` option (https://github.com/ansible-collections/community.hashi_vault/pull/96).

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -95,8 +95,20 @@ DOCUMENTATION = """
       version_added: 0.2.0
     username:
       description: Authentication user name.
+      env:
+        - name: ANSIBLE_HASHI_VAULT_USERNAME
+          version_added: '1.2.0'
+      vars:
+        - name: ansible_hashi_vault_username
+          version_added: '1.2.0'
     password:
       description: Authentication password.
+      env:
+        - name: ANSIBLE_HASHI_VAULT_PASSWORD
+          version_added: '1.2.0'
+      vars:
+        - name: ansible_hashi_vault_password
+          version_added: '1.2.0'
     role_id:
       description: Vault Role ID. Used in approle and aws_iam_login auth methods.
       env:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #54 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Note: still no tests for userpass, see #67 

Adds env:
- `ANSIBLE_HASHI_VAULT_USERNAME`
- `ANSIBLE_HASHI_VAULT_PASSWORD`

Add ansible vars:
- `ansible_hashi_vault_username`
- `ansible_hashi_vault_password`


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hashi_vault

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
