### PR TITLE
hashi_vault - add alternate methods (env, ini, vars) for `ca_cert` option

### DIFF
--- a/changelogs/fragments/97-ca_cert-env-and-vars.yml
+++ b/changelogs/fragments/97-ca_cert-env-and-vars.yml
@@ -1,3 +1,5 @@
 ---
 minor_changes:
-  - hashi_vault - add ``ANSIBLE_HASHI_VAULT_CA_CERT`` env var (with ``VAULT_CACERT`` low-precedence fallback) and ``ansible_hashi_vault_ca_cert`` ansible var for ``ca_cert`` option (https://github.com/ansible-collections/community.hashi_vault/pull/97).
+  - hashi_vault - add ``ANSIBLE_HASHI_VAULT_CA_CERT`` env var (with ``VAULT_CACERT`` low-precedence fallback) for ``ca_cert`` option (https://github.com/ansible-collections/community.hashi_vault/pull/97).
+  - hashi_vault - add ``ansible_hashi_vault_ca_cert`` ansible var for ``ca_cert`` option (https://github.com/ansible-collections/community.hashi_vault/pull/97).
+  - hashi_vault - add ``ca_cert`` INI config file key ``ca_cert`` option (https://github.com/ansible-collections/community.hashi_vault/pull/97).

--- a/changelogs/fragments/97-ca_cert-env-and-vars.yml
+++ b/changelogs/fragments/97-ca_cert-env-and-vars.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - hashi_vault - add ``ANSIBLE_HASHI_VAULT_CA_CERT`` env var (with ``VAULT_CACERT`` low-precedence fallback) and ``ansible_hashi_vault_ca_cert`` ansible var for ``ca_cert`` option (https://github.com/ansible-collections/community.hashi_vault/pull/97).

--- a/plugins/doc_fragments/connection.py
+++ b/plugins/doc_fragments/connection.py
@@ -51,6 +51,10 @@ class ModuleDocFragment(object):
         env:
           - name: ANSIBLE_HASHI_VAULT_CA_CERT
             version_added: '1.2.0'
+        ini:
+          - section: lookup_hashi_vault
+            key: ca_cert
+            version_added: '1.2.0'
         vars:
           - name: ansible_hashi_vault_ca_cert
             version_added: '1.2.0'

--- a/plugins/doc_fragments/connection.py
+++ b/plugins/doc_fragments/connection.py
@@ -48,6 +48,12 @@ class ModuleDocFragment(object):
         version_added: '1.1.0'
       ca_cert:
         description: Path to certificate to use for authentication.
+        env:
+          - name: ANSIBLE_HASHI_VAULT_CA_CERT
+            version_added: '1.2.0'
+        vars:
+          - name: ansible_hashi_vault_ca_cert
+            version_added: '1.2.0'
         aliases: [ cacert ]
       validate_certs:
         description:

--- a/plugins/module_utils/_hashi_vault_common.py
+++ b/plugins/module_utils/_hashi_vault_common.py
@@ -197,6 +197,7 @@ class HashiVaultOptionGroupBase:
         'namespace': ['VAULT_NAMESPACE'],
         'token': ['VAULT_TOKEN'],
         'url': ['VAULT_ADDR'],
+        'ca_cert': ['VAULT_CACERT'],
     }
 
     def __init__(self, option_adapter):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #75 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Adds env:
- `ANSIBLE_HASHI_VAULT_CA_CERT`
- `VAULT_CACERT` (low-precedence, see #10)

Adds vars:
- `ansible_hashi_vault_ca_cert`

Adds INI:
- `ca_cert` key in existing `lookup_hashi_vault` section.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hashi_vault

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
