### PR TITLE
prepare to deprecate python 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ See [the CI configuration](https://github.com/ansible-collections/community.hash
 
 ## Python Requirements
 
-**[Support for Python 2 will be dropped in `v2.0.0` of the collection.](https://github.com/ansible-collections/community.hashi_vault/issues/81)**
+**[Support for Python 2 & Python 3.5 will be dropped in `v2.0.0` of the collection.](https://github.com/ansible-collections/community.hashi_vault/issues/81)**
 
 Currently we test against Python versions:
 * 2.7

--- a/changelogs/fragments/107-deprecating-python-35.yml
+++ b/changelogs/fragments/107-deprecating-python-35.yml
@@ -1,0 +1,4 @@
+---
+deprecated_features:
+  - hashi_vault collection - support for Python 3.5 will be dropped in version ``2.0.0``
+    of ``community.hashi_vault`` (https://github.com/ansible-collections/community.hashi_vault/issues/81).

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,5 +1,6 @@
 hvac >= 0.10.6, != 0.10.12, != 0.10.13, < 1.0.0 ; python_version == '2.7' # bugs in 0.10.12 and 0.10.13 prevent it from working in Python 2
-hvac >= 0.10.6 ; python_version >= '3.5'
+hvac >= 0.10.6, < 1.0.0 ; python_version == '3.5' # py3.5 support will be dropped in 1.0.0
+hvac >= 0.10.6 ; python_version >= '3.6'
 
 # these should be satisfied naturally by the requests versions required by hvac anyway
 urllib3 >= 1.15 ; python_version >= '3.6' # we need raise_on_status for retry support to raise the correct exceptions https://github.com/urllib3/urllib3/blob/main/CHANGES.rst#115-2016-04-06

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,5 +1,6 @@
 hvac >= 0.10.6, != 0.10.12, != 0.10.13, < 1.0.0 ; python_version == '2.7' # bugs in 0.10.12 and 0.10.13 prevent it from working in Python 2
-hvac >= 0.10.6 ; python_version >= '3.5'
+hvac >= 0.10.6 ; < 1.0.0 ; python_version == '3.5' # py3.5 support will be dropped in 1.0.0
+hvac >= 0.10.6 ; python_version >= '3.6'
 
 # these should be satisfied naturally by the requests versions required by hvac anyway
 urllib3 >= 1.15 ; python_version >= '3.6' # we need raise_on_status for retry support to raise the correct exceptions https://github.com/urllib3/urllib3/blob/main/CHANGES.rst#115-2016-04-06

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,5 +1,5 @@
 hvac >= 0.10.6, != 0.10.12, != 0.10.13, < 1.0.0 ; python_version == '2.7' # bugs in 0.10.12 and 0.10.13 prevent it from working in Python 2
-hvac >= 0.10.6 ; < 1.0.0 ; python_version == '3.5' # py3.5 support will be dropped in 1.0.0
+hvac >= 0.10.6, < 1.0.0 ; python_version == '3.5' # py3.5 support will be dropped in 1.0.0
 hvac >= 0.10.6 ; python_version >= '3.6'
 
 # these should be satisfied naturally by the requests versions required by hvac anyway

--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -53,7 +53,7 @@ wrapt == 1.11.1
 
 # hvac
 hvac >= 0.10.6, != 0.10.12, != 0.10.13, < 1.0.0 ; python_version == '2.7' # bugs in 0.10.12 and 0.10.13 prevent it from working in Python 2
-hvac >= 0.10.6 ; < 1.0.0 ; python_version == '3.5' # py3.5 support will be dropped in 1.0.0
+hvac >= 0.10.6, < 1.0.0 ; python_version == '3.5' # py3.5 support will be dropped in 1.0.0
 hvac >= 0.10.6 ; python_version >= '3.6'
 
 # urllib3

--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -53,7 +53,8 @@ wrapt == 1.11.1
 
 # hvac
 hvac >= 0.10.6, != 0.10.12, != 0.10.13, < 1.0.0 ; python_version == '2.7' # bugs in 0.10.12 and 0.10.13 prevent it from working in Python 2
-hvac >= 0.10.6 ; python_version >= '3.5'
+hvac >= 0.10.6 ; < 1.0.0 ; python_version == '3.5' # py3.5 support will be dropped in 1.0.0
+hvac >= 0.10.6 ; python_version >= '3.6'
 
 # urllib3
 # these should be satisfied naturally by the requests versions required by hvac anyway


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Related: #81 & #82

Will rebase after #106 to re-apply commits and update the new `requirements.txt` for integration tests.

* Update requirements and constraints in accordance with the recent info from `hvac` around deprecating py3.5 at the same time as py2
* Update readme to indicate py3.5 deprecation
* Add changelog fragment to ensure py3.5 deprecation gets into porting guide


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
