### PR TITLE
docs PR comments

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,6 +39,10 @@ jobs:
         with:
           path: ${{ env.COLLECTION_PATH }}
 
+      ######## IMPORTANT
+      # Do not change these checkout and apply tasks lightly, we only want the docs from the PR side.
+      # Please read ALL of this document before changing these:
+      # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
       - name: Check out PR to temp location
         if: github.event_name == 'pull_request'
         uses: actions/checkout@v2
@@ -91,6 +95,18 @@ jobs:
             echo "SITE_NAME=${SITE_STUB}-pr${{ github.event.number }}" >> $GITHUB_ENV
           fi
 
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
+      - name: Install Surge
+        run: npm install -g surge
+
+      - name: Publish site
+        working-directory: ${{ env.HTML }}
+        run: surge ./ ${SITE_NAME}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+
       - name: Look for existing comment
         if: github.event_name == 'pull_request'
         id: fc
@@ -106,25 +122,14 @@ jobs:
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.number }}
-          body: |
-            ##Docs Build
-
-            📝 First pass at a PR comment!
-
-            Your doc build is available as an artifact on this run:
-            https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-            Site-to-be: https://${{ env.SITE_NAME }}.surge.sh
           edit-mode: replace
+          body: |
+            ##Docs Build 📝
 
-      - name: Install Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14
+            Thank you for contribution!✨
 
-      - name: Install Surge
-        run: npm install -g surge
+            The docs for this PR have been published here:
+            https://${{ env.SITE_NAME }}.surge.sh
 
-      - name: Publish site
-        working-directory: ${{ env.HTML }}
-        run: surge ./ ${SITE_NAME}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+            The docsite is available for download as an artifact on this run:
+            https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,17 +6,12 @@ on:
   push:
     branches:
       - main
-    paths:
-      - '.github/workflows/docs.yml'
-      - 'docs/**'
-      - 'CHANGELOG.rst'
-      - 'changelogs/changelog.yaml'
   pull_request_target:
-    paths:
-      - '.github/workflows/docs.yml'
-      - 'docs/**'
-      - 'CHANGELOG.rst'
-      - 'changelogs/changelog.yaml'
+    # paths:
+    #   - '.github/workflows/docs.yml'
+    #   - 'docs/**'
+    #   - 'CHANGELOG.rst'
+    #   - 'changelogs/changelog.yaml'
   schedule:
     - cron: '0 13 * * *'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,12 +44,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          path: /tmp/pr
+          path: ${{ runner.temp }}/pr
 
       - name: Apply docs changes from PR
         if: github.event_name == 'pull_request'
         working-directory: ${{ env.COLLECTION_PATH }}
-        run: rsync -avc --delete-after /tmp/pr/docs/docsite/ docs/docsite/
+        run: rsync -avc --delete-after "${{ runner.temp }}/pr/docs/docsite/" docs/docsite/
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request: #_target
     paths:
       - '.github/workflows/docs.yml'
       - 'docs/**'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,11 +7,11 @@ on:
     branches:
       - main
   pull_request_target:
-    # paths:
-    #   - '.github/workflows/docs.yml'
-    #   - 'docs/**'
-    #   - 'CHANGELOG.rst'
-    #   - 'changelogs/changelog.yaml'
+    paths:
+      - '.github/workflows/docs.yml'
+      - 'docs/**'
+      - 'CHANGELOG.rst'
+      - 'changelogs/changelog.yaml'
   schedule:
     - cron: '0 13 * * *'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,12 +44,14 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          path: ${{ runner.temp }}/pr
+          path: __pr
 
       - name: Apply docs changes from PR
         if: github.event_name == 'pull_request'
         working-directory: ${{ env.COLLECTION_PATH }}
-        run: rsync -avc --delete-after "${{ runner.temp }}/pr/docs/docsite/" docs/docsite/
+        run: |
+          rsync -avc --delete-after "${{ github.workspace }}/__pr/docs/docsite/" docs/docsite/
+          rm -rf "${{ github.workspace }}/__pr"
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Determine docsite subdomain
         run: |
-          if [[ "${GITHUB_EVENT_NAME}" -eq "push" ]]; then
+          if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
             echo "SITE_NAME=${SITE_STUB}-main" >> $GITHUB_ENV
           else
             echo "SITE_NAME=${SITE_STUB}-pr${{ github.event.number }}" >> $GITHUB_ENV
@@ -112,9 +112,9 @@ jobs:
             📝 First pass at a PR comment!
 
             Your doc build is available as an artifact on this run:
-            https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+            https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-            Site-to-be: https://${SITE_NAME}.surge.sh
+            Site-to-be: https://${{ env.SITE_NAME }}.surge.sh
           edit-mode: replace
 
       - name: Install Node

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,12 +4,14 @@ on:
   # we want to ensure the docs are still good before doing a release
   # so we try to catch that with the changelog changes
   push:
+    branches:
+      - main
     paths:
       - '.github/workflows/docs.yml'
       - 'docs/**'
       - 'CHANGELOG.rst'
       - 'changelogs/changelog.yaml'
-  pull_request:
+  pull_request_target:
     paths:
       - '.github/workflows/docs.yml'
       - 'docs/**'
@@ -31,6 +33,7 @@ jobs:
         uses: briantist/ezenv@v1
         with:
           env: |
+            SITE_STUB=community-hashi-vault
             COLLECTION_PATH=ansible_collections/${NAMESPACE}/${COLLECTION_NAME}
             DOCS=${COLLECTION_PATH}/docs
             DOCS_PREVIEW=${DOCS}/preview
@@ -40,6 +43,18 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ${{ env.COLLECTION_PATH }}
+
+      - name: Check out PR to temp location
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: /tmp/pr
+
+      - name: Apply docs changes from PR
+        if: github.event_name == 'pull_request_target'
+        working-directory: ${{ env.COLLECTION_PATH }}
+        run: rsync -avc --delete-after /tmp/pr/docs/docsite/ docs/docsite/
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -70,3 +85,49 @@ jobs:
           name: html_docsite
           path: ${{ env.HTML }}
           retention-days: 7
+
+      - name: Determine docsite subdomain
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" -eq "push" ]]; then
+            echo "SITE_NAME=${SITE_STUB}-main" >> $GITHUB_ENV
+          else
+            echo "SITE_NAME=${SITE_STUB}-pr${{ github.event.number }}" >> $GITHUB_ENV
+          fi
+
+      - name: Look for existing comment
+        if: github.event_name == 'pull_request_target'
+        id: fc
+        uses: peter-evans/find-comment@v1
+        with:
+          issue-number: ${{ github.event.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: "##Docs Build"
+
+      - name: Post a comment on the PR
+        if: github.event_name == 'pull_request_target'
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.number }}
+          body: |
+            ##Docs Build
+
+            📝 First pass at a PR comment!
+
+            Your doc build is available as an artifact on this run:
+            https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+
+            Site-to-be: https://${SITE_NAME}.surge.sh
+          edit-mode: replace
+
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
+      - name: Install Surge
+        run: npm install -g surge
+
+      - name: Publish site
+        working-directory: ${{ env.HTML }}
+        run: surge ./ --token ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - main
-  pull_request: #_target
+  pull_request_target:
     paths:
       - '.github/workflows/docs.yml'
       - 'docs/**'
@@ -44,14 +44,14 @@ jobs:
       # Please read ALL of this document before changing these:
       # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
       - name: Check out PR to temp location
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: __pr
 
       - name: Apply docs changes from PR
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         working-directory: ${{ env.COLLECTION_PATH }}
         run: |
           rsync -avc --delete-after "${{ github.workspace }}/__pr/docs/docsite/" docs/docsite/
@@ -108,7 +108,7 @@ jobs:
         run: surge ./ ${SITE_NAME}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
 
       - name: Look for existing comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         id: fc
         uses: peter-evans/find-comment@v1
         with:
@@ -117,7 +117,7 @@ jobs:
           body-includes: "##Docs Build"
 
       - name: Post a comment on the PR
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         uses: peter-evans/create-or-update-comment@v1
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,14 +40,14 @@ jobs:
           path: ${{ env.COLLECTION_PATH }}
 
       - name: Check out PR to temp location
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: /tmp/pr
 
       - name: Apply docs changes from PR
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         working-directory: ${{ env.COLLECTION_PATH }}
         run: rsync -avc --delete-after /tmp/pr/docs/docsite/ docs/docsite/
 
@@ -90,7 +90,7 @@ jobs:
           fi
 
       - name: Look for existing comment
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         id: fc
         uses: peter-evans/find-comment@v1
         with:
@@ -99,7 +99,7 @@ jobs:
           body-includes: "##Docs Build"
 
       - name: Post a comment on the PR
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         uses: peter-evans/create-or-update-comment@v1
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
@@ -125,4 +125,4 @@ jobs:
 
       - name: Publish site
         working-directory: ${{ env.HTML }}
-        run: surge ./ --token ${{ secrets.SURGE_TOKEN }}
+        run: surge ./ ${SITE_NAME}.surge.sh --token ${{ secrets.SURGE_TOKEN }}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
So, this change enabled the docs build workflow to:
- publish the docsite to a surge.sh site !!!!
- post (and subsequently edit) a comment on the PR that links to the job run (where the artifact can be downloaded), as well a link to the surge site

On `push` (only to `main`) the surge site for main will be updated.
On a PR, the site name is dynamically generated with the PR number.

A `pull_request` event that comes from a fork (most of them, including the ones from me), doesn't have access to GitHub secrets (for the surge token), and doesn't have write access (can't post comments).

So the idea is to use `pull_request_target` which runs in the context of the base branch, and has all the permissions. One issue with this is that the default checkout won't have the changes from the PR. This is intentional, to avoid running untrusted code that will have access to secrets and a gitub token with write access. We do an intentional checkout of the PR's head, and copy **only the docsite** into the main checkout.

The second issue is that when I try to use `pull_request_target`, it's not running at all. I suspect this is because it doesn't yet exist in main. So I'm going to merge this, then open a new docs PR to see if it triggers....

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
