### PR TITLE
add docsite unpublish on PR close

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
   pull_request_target:
+    types: [opened, synchronize, reopened, closed]
     paths:
       - '.github/workflows/docs.yml'
       - 'docs/**'
@@ -20,6 +21,65 @@ env:
   COLLECTION_NAME: hashi_vault
 
 jobs:
+  unpublish:
+    name: Clean up closed PR
+    if: >-
+      github.event_name == 'pull_request_target'
+      && github.event.action == 'closed'
+      && github.repository == 'ansible-collections/community.hashi_vault'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set site name
+        run: |
+          export SITE_STUB=community-hashi-vault
+          echo "SITE_NAME=${SITE_STUB}-pr${{ github.event.number }}" >> $GITHUB_ENV
+
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
+      - name: Install Surge
+        run: npm install -g surge
+
+      - name: Publish site
+        run: surge teardown ${SITE_NAME}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+
+      - name: Look for existing comment
+        id: fc
+        uses: peter-evans/find-comment@v1
+        with:
+          issue-number: ${{ github.event.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: "##Docs Build"
+
+      - name: Post a comment on a merged PR
+        if: github.event.pull_request.merged
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.number }}
+          edit-mode: replace
+          body: |
+            ##Docs Build 📝
+
+            Thank you for contribution!✨
+
+            This PR has been merged and the docs are now incorporated into `main`:
+            https://${{ env.SITE_NAME_MAIN }}.surge.sh
+
+      - name: Post a comment on a closed PR
+        if: github.event.pull_request.merged
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.number }}
+          edit-mode: replace
+          body: |
+            ##Docs Build 📝
+
+            This PR is closed and any previously published docsite has been unpublished.
+
   docs:
     name: Collection Docs Lint & Build
     runs-on: ubuntu-latest
@@ -135,7 +195,7 @@ jobs:
             The docs for **this PR** have been published here:
             https://${{ env.SITE_NAME }}.surge.sh
 
-            You can compare to the docs for the ``main`` branch here:
+            You can compare to the docs for the `main` branch here:
             https://${{ env.SITE_NAME_MAIN }}.surge.sh
 
             The docsite for **this PR** is also available for download as an artifact from this run:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Surge
         run: npm install -g surge
 
-      - name: Publish site
+      - name: Unpublish site
         run: surge teardown ${SITE_NAME}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
 
       - name: Look for existing comment


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This should allow for unpublishing PR-specific docsites when the PR is closed.

As with all `pull_request_targets`, I can't test it without merging it, so this PR is here as an explanation to describe / discuss the change. Any additional direct commits related to this will be linked here.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
