### PR TITLE
docs - have docs build on all changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,11 +8,6 @@ on:
       - main
   pull_request_target:
     types: [opened, synchronize, reopened, closed]
-    paths:
-      - '.github/workflows/docs.yml'
-      - 'docs/**'
-      - 'CHANGELOG.rst'
-      - 'changelogs/changelog.yaml'
   schedule:
     - cron: '0 13 * * *'
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This changes the doc build to no longer be limited to PRs that change docs. The reason is that the doc build also includes plugin and module documentation changes, so we might as well ensure that all PRs have it built so we can preview those changes as well.

(no changes will be visible with this PR, will rebase #113 to test after merging)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
