### PR TITLE
CI - set timeout on installing docker on macos

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -328,6 +328,8 @@ jobs:
 
       - name: Install Docker on MacOS
         if: ${{ matrix.runner == 'macos-latest' && matrix.docker }}
+        timeout-minutes: 6
+        # sometimes this hangs forever waiting for an IP
         uses: ./.github/actions/macos-docker
 
       - name: Pull Ansible test images

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,6 +41,7 @@ jobs:
         run: npm install -g surge
 
       - name: Unpublish site
+        continue-on-error: true
         run: surge teardown ${SITE_NAME}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
 
       - name: Look for existing comment


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
GHA's MacOS is pretty flaky and times vary for a lot of things. Installing Docker can take under 2 minutes or sometimes close to 5 minutes. Other times it seemingly hangs forever, waiting for an IP assignment or some other issue.

Let's set a timeout for that step to 6 minutes, so that it'll fail (relatively) quickly, and we can restart CI.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
