### PR TITLE
ci - ansible-codecov action: pin version

### DIFF
--- a/.github/actions/ansible-codecov/action.yml
+++ b/.github/actions/ansible-codecov/action.yml
@@ -33,6 +33,12 @@ inputs:
       See https://uploader.codecov.io/linux for the versions available.
     required: false
     default: latest
+  fail-on-error:
+    description: |
+      If 'true' then codecov will be called with '-Z', which will fail the build on an error.
+      Any value other than 'true' will be treated as false.
+    required: false
+    default: 'true'
 runs:
   using: composite
   steps:
@@ -69,3 +75,4 @@ runs:
         --directory-flag-pattern "${{ inputs.file-flag-pattern }}"
         --file-flag-pattern "${{ inputs.file-flag-pattern }}"
         --additional-flags "${{ inputs.additional-flags }}"
+        ${{ inputs.fail-on-error == 'true' && '--fail-on-error' || '' }}

--- a/.github/actions/ansible-codecov/action.yml
+++ b/.github/actions/ansible-codecov/action.yml
@@ -27,6 +27,12 @@ inputs:
   directory:
     description: The directory to scan recursively. Defaults to current working directory.
     required: false
+  codecov-uploader-version:
+    description: |
+      The version of the codecov uploader to use. 'latest' (default) always gets the latest.
+      See https://uploader.codecov.io/linux for the versions available.
+    required: false
+    default: latest
 runs:
   using: composite
   steps:
@@ -44,9 +50,9 @@ runs:
             ./codecov --version
         else
             curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --import # One-time step
-            curl -Os https://uploader.codecov.io/latest/linux/codecov
-            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+            curl -Os https://uploader.codecov.io/${{ inputs.codecov-uploader-version }}/linux/codecov
+            curl -Os https://uploader.codecov.io/${{ inputs.codecov-uploader-version }}/linux/codecov.SHA256SUM
+            curl -Os https://uploader.codecov.io/${{ inputs.codecov-uploader-version }}/linux/codecov.SHA256SUM.sig
             gpg --verify codecov.SHA256SUM.sig codecov.SHA256SUM
             shasum -a 256 -c codecov.SHA256SUM
             chmod +x codecov

--- a/.github/actions/ansible-codecov/process.py
+++ b/.github/actions/ansible-codecov/process.py
@@ -28,13 +28,14 @@ def get_flags(pattern, input):
 
 
 def main(argv):
-    additional_flags = file_flag_pattern = directory_flag_pattern = directory = None
+    additional_flags = file_flag_pattern = directory_flag_pattern = directory = fail_on_error = None
 
     opts, args = getopt.getopt(argv, '', [
         'directory=',
         'directory-flag-pattern=',
         'file-flag-pattern=',
         'additional-flags=',
+        'fail-on-error',
     ])
 
     for opt, arg in opts:
@@ -46,6 +47,8 @@ def main(argv):
             file_flag_pattern = arg
         elif opt == '--additional-flags':
             additional_flags = arg
+        elif opt == '--fail-on-error':
+            fail_on_error = True
 
     extra_flags = additional_flags.split(',') if additional_flags else []
 
@@ -75,6 +78,8 @@ def main(argv):
         cmd = ['codecov', '-F', flag]
         [cmd.extend(['-F', extra]) for extra in extra_flags]
         [cmd.extend(['-f', file]) for file in files]
+        if fail_on_error:
+            cmd.append('-Z')
 
         print('::group::Flag: %s%s' % (flag, logextra))
 

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -410,7 +410,7 @@ jobs:
       - name: Upload Ansible pre-2.12 unit coverage reports to Codecov
         uses: ./.github/actions/ansible-codecov
         with:
-          codecov-uploader-version: v0.1.0_6943
+          codecov-uploader-version: v0.1.0_8278
           directory: ./cov-units-pre2.12
           additional-flags: units
           file-flag-pattern: coverage=units=units={env_%}=python-{py%}.xml
@@ -420,6 +420,6 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: ./.github/actions/ansible-codecov
         with:
-          codecov-uploader-version: v0.1.0_6943
+          codecov-uploader-version: v0.1.0_8278
           directory: ./cov
           directory-flag-pattern: =ansible_{ansible-%}=

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -410,6 +410,7 @@ jobs:
       - name: Upload Ansible pre-2.12 unit coverage reports to Codecov
         uses: ./.github/actions/ansible-codecov
         with:
+          codecov-uploader-version: v0.1.0_6943
           directory: ./cov-units-pre2.12
           additional-flags: units
           file-flag-pattern: coverage=units=units={env_%}=python-{py%}.xml
@@ -419,5 +420,6 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: ./.github/actions/ansible-codecov
         with:
+          codecov-uploader-version: v0.1.0_6943
           directory: ./cov
           directory-flag-pattern: =ansible_{ansible-%}=


### PR DESCRIPTION
##### SUMMARY
Add two inputs to `ansible-codecov` action:
- `fail-on-error` -- if `'true'` it invokes `codecov` with `-Z` so that it will return an error code and fail the build in a way that's obvious. Defaults to `'true'`.
- `codecov-uploader-version` -- defaults to `latest` but can be set to a specific version so that we can pin. Since `codecov` releases new builds without changing their version number, it's difficult to tell if new errors are the result of a new build because the build number is not included in the output at all.

And then finally:
- pin our version to build ~6943~ 8278 to fix https://github.com/codecov/uploader/issues/303

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
