### PR TITLE
docs build - diff rendering and changes to changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,7 @@ on:
 env:
   NAMESPACE: community
   COLLECTION_NAME: hashi_vault
+  NOT_A_FORK: ${{ github.repository == 'ansible-collections/community.hashi_vault' }}
 
 jobs:
   unpublish:
@@ -21,7 +22,7 @@ jobs:
     if: >-
       github.event_name == 'pull_request_target'
       && github.event.action == 'closed'
-      && github.repository == 'ansible-collections/community.hashi_vault'
+      && fromJSON(env.NOT_A_FORK)
     runs-on: ubuntu-latest
     steps:
       - name: Set up env vars
@@ -200,7 +201,7 @@ jobs:
 
       - name: Install Node
         if: >-
-          github.repository == 'ansible-collections/community.hashi_vault'
+          fromJSON(env.NOT_A_FORK)
           && fromJSON(env.PUBLISH)
         uses: actions/setup-node@v2
         with:
@@ -208,13 +209,13 @@ jobs:
 
       - name: Install Surge
         if: >-
-          github.repository == 'ansible-collections/community.hashi_vault'
+          fromJSON(env.NOT_A_FORK)
           && fromJSON(env.PUBLISH)
         run: npm install -g surge
 
       - name: Publish site
         if: >-
-          github.repository == 'ansible-collections/community.hashi_vault'
+          fromJSON(env.NOT_A_FORK)
           && fromJSON(env.PUBLISH)
         working-directory: ${{ env.HTML }}
         run: surge ./ ${SITE_NAME}.surge.sh --token ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -178,7 +178,10 @@ jobs:
       - name: Generate docs diff
         if: fromJSON(env.PUBLISH)
         run: |
-          DOC_DIFF=$(git diff --no-index "${BASE_DOCS_RENDERED}" "${PR_DOCS_RENDERED}")
+          ls -alh "${BASE_DOCS_RENDERED}" || true
+          ls -alh "${PR_DOCS_RENDERED}" || true
+
+          DOC_DIFF=$(git --no-pager diff --no-index "${BASE_DOCS_RENDERED}" "${PR_DOCS_RENDERED}")
           echo "DOC_DIFF=${DOC_DIFF}" >> ${GITHUB_ENV}
 
       - name: Upload Docsite artifact

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -97,6 +97,8 @@ jobs:
             DOCS_PREVIEW=${DOCS}/preview
             DOCS_BUILD=${DOCS_PREVIEW}/build
             HTML=${DOCS_BUILD}/html
+            BASE_DOCS_RENDERED=${{ runner.temp }}/html/base
+            PR_DOCS_RENDERED=${{ runner.temp }}/html/pr
 
       - name: Check out code
         uses: actions/checkout@v2
@@ -119,9 +121,11 @@ jobs:
           ANSIBLE_COLLECTIONS_PATH: ${{ github.workspace }}
         run: ${DOCS_PREVIEW}/build.sh
 
-      - name: Save the base hash # and discard the build
+      - name: Save the base build & hash # and discard the build
         run: |
           echo "BASE_DOCS_HASH=${{ hashFiles(env.HTML) }}" >> $GITHUB_ENV
+          rsync -avc --delete-after "${HTML}" "${BASE_DOCS_RENDERED}"
+
 
       ######## IMPORTANT
       # Do not change these checkout and apply tasks lightly, we only want the docs from the PR side.
@@ -156,7 +160,9 @@ jobs:
 
       - name: Save the head hash
         if: github.event_name == 'pull_request_target'
-        run: echo "HEAD_DOCS_HASH=${{ hashFiles(env.HTML) }}" >> $GITHUB_ENV
+        run: |
+          echo "HEAD_DOCS_HASH=${{ hashFiles(env.HTML) }}" >> $GITHUB_ENV
+          rsync -avc --delete-after "${HTML}" "${PR_DOCS_RENDERED}"
 
       - name: Should publish?
         run: |
@@ -166,6 +172,12 @@ jobs:
           else
             echo "PUBLISH=false" >> $GITHUB_ENV
           fi
+
+      - name: Generate docs diff
+        if: fromJSON(env.PUBLISH)
+        run: |
+          DOC_DIFF=$(git diff --no-index "${BASE_DOCS_RENDERED}" "${PR_DOCS_RENDERED}")
+          echo "DOC_DIFF=${DOC_DIFF}" >> ${GITHUB_ENV}
 
       - name: Upload Docsite artifact
         uses: actions/upload-artifact@v2
@@ -237,3 +249,12 @@ jobs:
 
             The docsite for **this PR** is also available for download as an artifact from this run:
             https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            <details>
+            <summary>Click to see the diff comparison.</summary>
+
+            ```diff
+            ${{ env.DOC_DIFF }}
+            ```
+
+            </details>

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -181,6 +181,7 @@ jobs:
           ls -alh "${BASE_DOCS_RENDERED}" || true
           ls -alh "${PR_DOCS_RENDERED}" || true
 
+          git --no-pager diff --no-index "${BASE_DOCS_RENDERED}" "${PR_DOCS_RENDERED}"
           DOC_DIFF=$(git --no-pager diff --no-index "${BASE_DOCS_RENDERED}" "${PR_DOCS_RENDERED}")
           echo "DOC_DIFF=${DOC_DIFF}" >> ${GITHUB_ENV}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -178,7 +178,7 @@ jobs:
       - name: Generate docs diff
         if: fromJSON(env.PUBLISH)
         run: |
-          DOC_DIFF=$(git --no-pager diff --no-index "${BASE_DOCS_RENDERED}" "${PR_DOCS_RENDERED} || true")
+          DOC_DIFF=$(git --no-pager diff --no-index "${BASE_DOCS_RENDERED}" "${PR_DOCS_RENDERED}" || true)
           echo "DOC_DIFF=${DOC_DIFF}" >> ${GITHUB_ENV}
 
       - name: Upload Docsite artifact

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -178,11 +178,7 @@ jobs:
       - name: Generate docs diff
         if: fromJSON(env.PUBLISH)
         run: |
-          ls -alh "${BASE_DOCS_RENDERED}" || true
-          ls -alh "${PR_DOCS_RENDERED}" || true
-
-          git --no-pager diff --no-index "${BASE_DOCS_RENDERED}" "${PR_DOCS_RENDERED}"
-          DOC_DIFF=$(git --no-pager diff --no-index "${BASE_DOCS_RENDERED}" "${PR_DOCS_RENDERED}")
+          DOC_DIFF=$(git --no-pager diff --no-index "${BASE_DOCS_RENDERED}" "${PR_DOCS_RENDERED} || true")
           echo "DOC_DIFF=${DOC_DIFF}" >> ${GITHUB_ENV}
 
       - name: Upload Docsite artifact

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -124,6 +124,7 @@ jobs:
       - name: Save the base build & hash # and discard the build
         run: |
           echo "BASE_DOCS_HASH=${{ hashFiles(env.HTML) }}" >> $GITHUB_ENV
+          mkdir -p "${BASE_DOCS_RENDERED}"
           rsync -avc --delete-after "${HTML}" "${BASE_DOCS_RENDERED}"
 
 
@@ -162,6 +163,7 @@ jobs:
         if: github.event_name == 'pull_request_target'
         run: |
           echo "HEAD_DOCS_HASH=${{ hashFiles(env.HTML) }}" >> $GITHUB_ENV
+          mkdir -p "${PR_DOCS_RENDERED}"
           rsync -avc --delete-after "${HTML}" "${PR_DOCS_RENDERED}"
 
       - name: Should publish?

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
     if: >-
       github.event_name == 'pull_request_target'
       && github.event.action == 'closed'
-      && fromJSON(env.NOT_A_FORK)
+      && github.repository == 'ansible-collections/community.hashi_vault'
     runs-on: ubuntu-latest
     steps:
       - name: Set up env vars

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -178,8 +178,9 @@ jobs:
       - name: Generate docs diff
         if: fromJSON(env.PUBLISH)
         run: |
-          DOC_DIFF=$(git --no-pager diff --no-index "${BASE_DOCS_RENDERED}" "${PR_DOCS_RENDERED}" || true)
-          echo "DOC_DIFF=${DOC_DIFF}" >> ${GITHUB_ENV}
+          echo 'DOC_DIFF<<EOF' >> ${GITHUB_ENV}
+          git --no-pager diff --no-index "${BASE_DOCS_RENDERED}" "${PR_DOCS_RENDERED}" >> ${GITHUB_ENV} || true
+          echo 'EOF' >> ${GITHUB_ENV}
 
       - name: Upload Docsite artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,6 @@
 ---
 name: Collection Docs
 on:
-  # we want to ensure the docs are still good before doing a release
-  # so we try to catch that with the changelog changes
   push:
     branches:
       - main
@@ -184,6 +182,7 @@ jobs:
           echo 'EOF' >> ${GITHUB_ENV}
 
       - name: Upload Docsite artifact
+        if: fromJSON(env.PUBLISH)
         uses: actions/upload-artifact@v2
         with:
           name: html_docsite
@@ -191,7 +190,6 @@ jobs:
           retention-days: 7
 
       - name: Determine docsite subdomain
-        if: fromJSON(env.PUBLISH)
         run: |
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request_target" ]]; then
             echo "SITE_NAME=${SITE_STUB}-pr${{ github.event.number }}" >> $GITHUB_ENV
@@ -200,17 +198,13 @@ jobs:
           fi
 
       - name: Install Node
-        if: >-
-          fromJSON(env.NOT_A_FORK)
-          && fromJSON(env.PUBLISH)
+        if: fromJSON(env.NOT_A_FORK)
         uses: actions/setup-node@v2
         with:
           node-version: 14
 
       - name: Install Surge
-        if: >-
-          fromJSON(env.NOT_A_FORK)
-          && fromJSON(env.PUBLISH)
+        if: fromJSON(env.NOT_A_FORK)
         run: npm install -g surge
 
       - name: Publish site
@@ -220,16 +214,36 @@ jobs:
         working-directory: ${{ env.HTML }}
         run: surge ./ ${SITE_NAME}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
 
-      - name: Look for existing comment
+      # there might have been changes published before, which were removed in a subsequent commit
+      - name: Unpublish site
         if: >-
-          github.event_name == 'pull_request_target'
-          && fromJSON(env.PUBLISH)
+          fromJSON(env.NOT_A_FORK)
+          && !fromJSON(env.PUBLISH)
+        continue-on-error: true
+        run: surge teardown ${SITE_NAME}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+
+      - name: Look for existing comment
+        if: github.event_name == 'pull_request_target'
         id: fc
         uses: peter-evans/find-comment@v1
         with:
           issue-number: ${{ github.event.number }}
           comment-author: 'github-actions[bot]'
           body-includes: "##Docs Build"
+
+      - name: Remove previous comment
+        if: >-
+          fromJSON(env.NOT_A_FORK)
+          && !fromJSON(env.PUBLISH)
+          && steps.fc.outputs.comment-id
+        uses: actions/github-script@v4
+        with:
+          script: |
+            github.issues.deleteComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: ${{ steps.fc.outputs.comment-id }}
+            })
 
       - name: Post a comment on the PR
         if: >-


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changes to docs build:
- a `git diff` is used to show the differences between the rendered docs in the target vs the PR, and hidden behind an expandable box (tested via #136)
- A PR that has docs changes and then doesn't have any more will not correctly unpublish the site and remove the PR comment (tested via #137)
- ^ this can happen if a PR was not rebased against a newer version of `main` that has docs changes, or can happen when changes to docs (intentional or accidental) in a PR are removed in a later commit, so that there is no longer any doc change.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
