### PR TITLE
Updating Vault versions in tests and CI

### DIFF
--- a/.github/actions/docker-image-versions/action.yml
+++ b/.github/actions/docker-image-versions/action.yml
@@ -31,6 +31,10 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Requirements
+      shell: bash
+      run: pip install -r "${{ github.action_path }}/requirements.txt"
+
     - shell: bash
       id: versions
       run: >-

--- a/.github/actions/docker-image-versions/action.yml
+++ b/.github/actions/docker-image-versions/action.yml
@@ -1,0 +1,43 @@
+---
+name: Get a list of docker image versions
+description: Gets a list of docker image versions (via tags), limited to a specified number of major, minor, and micro combinations.
+outputs:
+  versions:
+      description: JSON encoded list of versions.
+      value: ${{ steps.versions.outputs.versions }}
+inputs:
+  image:
+    description: The docker image name.
+    required: false
+    default: vault
+  num_major_versions:
+    description: Number of unique major versions to return.
+    required: false
+    default: '1'
+  num_minor_versions:
+    description: Number of unique minor versions to return.
+    required: false
+    default: '3'
+  num_micro_versions:
+    description: Number of unique micro versions to return.
+    required: false
+    default: '1'
+  include_prerelease:
+    description: If 'true' then pre-release versions are included. Any value other than 'true' will be treated as false.
+    required: false
+  include_postrelease:
+    description: If 'true' then post-release versions are included. Any value other than 'true' will be treated as false.
+    required: false
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      id: versions
+      run: >-
+        python -u "${{ github.action_path }}/versions.py"
+        --image "${{ inputs.image }}"
+        --num_major_versions "${{ inputs.num_major_versions }}"
+        --num_minor_versions "${{ inputs.num_minor_versions }}"
+        --num_micro_versions "${{ inputs.num_micro_versions }}"
+        ${{ inputs.include_prerelease == 'true' && '--include_prerelease' || '' }}
+        ${{ inputs.include_postrelease == 'true' && '--include_postrelease' || '' }}

--- a/.github/actions/docker-image-versions/action.yml
+++ b/.github/actions/docker-image-versions/action.yml
@@ -17,7 +17,7 @@ inputs:
   num_minor_versions:
     description: Number of unique minor versions to return.
     required: false
-    default: '3'
+    default: '1'
   num_micro_versions:
     description: Number of unique micro versions to return.
     required: false

--- a/.github/actions/docker-image-versions/requirements.txt
+++ b/.github/actions/docker-image-versions/requirements.txt
@@ -1,0 +1,3 @@
+requests
+packaging
+urllib3 >= 1.15

--- a/.github/actions/docker-image-versions/versions.py
+++ b/.github/actions/docker-image-versions/versions.py
@@ -21,6 +21,7 @@ from packaging import version
 
 TAG_URI = 'https://registry.hub.docker.com/v2/repositories/library/%s/tags?page_size=1024'
 
+
 def main(argv):
     image = None
     include_prerelease = include_postrelease = False
@@ -68,7 +69,7 @@ def main(argv):
         vobj = None
         try:
             vobj = version.parse(tag['name'])
-        except:
+        except Exception:
             pass
 
         if vobj is None or isinstance(vobj, version.LegacyVersion):

--- a/.github/actions/docker-image-versions/versions.py
+++ b/.github/actions/docker-image-versions/versions.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2012, Brian Scholer (@briantist)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import sys
+import getopt
+
+import json
+
+import requests
+from urllib3.util.retry import Retry
+from requests.adapters import HTTPAdapter
+
+from packaging import version
+
+
+TAG_URI = 'https://registry.hub.docker.com/v2/repositories/library/%s/tags?page_size=1024'
+
+def main(argv):
+    image = None
+    include_prerelease = include_postrelease = False
+    num_major_versions = 1
+    num_minor_versions = 3
+    num_micro_versions = 1
+
+    opts, args = getopt.getopt(argv, '', [
+        'image=',
+        'num_major_versions=',
+        'num_minor_versions=',
+        'num_micro_versions=',
+        'include_prerelease',
+        'include_postrelease',
+    ])
+
+    for opt, arg in opts:
+        if opt == '--image':
+            image = arg
+        elif opt == '--num_major_versions':
+            num_major_versions = int(arg)
+        elif opt == '--num_minor_versions':
+            num_minor_versions = int(arg)
+        elif opt == '--num_micro_versions':
+            num_micro_versions = int(arg)
+        elif opt == '--include_prerelease':
+            include_prerelease = True
+        elif opt == '--include_postrelease':
+            include_postrelease = True
+
+    if image is None:
+        raise ValueError('image must be supplied.')
+
+    tag_url = TAG_URI % image
+
+    sess = requests.Session()
+    retry = Retry(total=5, backoff_factor=0.2)
+    adapter = HTTPAdapter(max_retries=retry)
+    sess.mount('https://', adapter)
+
+    response = sess.get(tag_url)
+
+    versions = []
+    for tag in response.json()['results']:
+        vobj = None
+        try:
+            vobj = version.parse(tag['name'])
+        except:
+            pass
+
+        if vobj is None or isinstance(vobj, version.LegacyVersion):
+            continue
+
+        if vobj.is_prerelease is include_prerelease and vobj.is_postrelease is include_postrelease:
+            versions.append(vobj)
+
+    majors = set()
+    minors = set()
+    micros = set()
+    keep = []
+    for ver in sorted(versions, reverse=True):
+        if ver.major not in majors:
+            if len(majors) == num_major_versions:
+                break
+            majors.add(ver.major)
+            minors.clear()
+            micros.clear()
+
+        if ver.minor not in minors:
+            if len(minors) == num_minor_versions:
+                continue
+            minors.add(ver.minor)
+            micros.clear()
+
+        if ver.micro not in micros:
+            if len(micros) == num_micro_versions:
+                continue
+            micros.add(ver.micro)
+
+        keep.append(str(ver))
+
+    print('::set-output name=versions::%s' % json.dumps(keep))
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -233,6 +233,8 @@ jobs:
       - name: Get Vault versions
         id: vault_versions
         uses: ./.github/actions/docker-image-versions
+        with:
+          num_minor_versions: 2
 
       - name: Install ansible-base (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -246,7 +246,7 @@ jobs:
       - name: Set Vault Version (1)
         uses: briantist/ezenv@v1
         with:
-          env: VAULT_VERSION=${{ fromJSON(steps.vault_versions.outputs.versions)[0]
+          env: VAULT_VERSION=${{ fromJSON(steps.vault_versions.outputs.versions)[0] }}
 
       - name: Prepare docker dependencies (Vault ${{ env.VAULT_VERSION }})
         run: ./setup.sh -e vault_version=${VAULT_VERSION}

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -259,7 +259,7 @@ jobs:
       - name: Set Vault Version (2)
         uses: briantist/ezenv@v1
         with:
-          env: VAULT_VERSION=${{ fromJSON(steps.vault_versions.outputs.versions)[1]
+          env: VAULT_VERSION=${{ fromJSON(steps.vault_versions.outputs.versions)[1] }}
 
       - name: Prepare docker dependencies (Vault ${{ env.VAULT_VERSION }})
         run: ./setup.sh -e vault_version=${VAULT_VERSION}
@@ -272,7 +272,7 @@ jobs:
       - name: Set Vault Version (3)
         uses: briantist/ezenv@v1
         with:
-          env: VAULT_VERSION=${{ fromJSON(steps.vault_versions.outputs.versions)[2]
+          env: VAULT_VERSION=${{ fromJSON(steps.vault_versions.outputs.versions)[2] }}
 
       - name: Prepare docker dependencies (Vault ${{ env.VAULT_VERSION }})
         run: ./setup.sh -e vault_version=${VAULT_VERSION}

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -67,6 +67,7 @@ jobs:
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
 
       - name: Pull Ansible test images
+        timeout-minutes: 5
         continue-on-error: true
         uses: ./.github/actions/pull-ansible-test-images
         with:
@@ -135,6 +136,7 @@ jobs:
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
 
       - name: Pull Ansible test images
+        timeout-minutes: 5
         continue-on-error: true
         uses: ./.github/actions/pull-ansible-test-images
         with:
@@ -197,7 +199,6 @@ jobs:
             python: 2.7
         include:
           - ansible: devel
-            vault: 1.7.3
             python: '3.10'
             runner: ubuntu-latest
             test_container: default
@@ -210,9 +211,6 @@ jobs:
             COLLECTION_PATH=ansible_collections/${NAMESPACE}/${COLLECTION_NAME}
             COLLECTION_INTEGRATION_PATH=${COLLECTION_PATH}/tests/integration
             COLLECTION_INTEGRATION_TARGETS=${COLLECTION_INTEGRATION_PATH}/targets
-            LOOKUP_HASHI_VAULT_PATH=${COLLECTION_INTEGRATION_TARGETS}/lookup_hashi_vault
-            LOOKUP_HASHI_VAULT_BIN=${LOOKUP_HASHI_VAULT_PATH}/lookup_hashi_vault/files/bin
-            LOOKUP_HASHI_VAULT_VARS=${LOOKUP_HASHI_VAULT_PATH}/lookup_hashi_vault/vars
 
       - name: Check out code
         uses: actions/checkout@v2
@@ -239,6 +237,7 @@ jobs:
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
 
       - name: Pull Ansible test images
+        timeout-minutes: 5
         continue-on-error: true
         uses: ./.github/actions/pull-ansible-test-images
         with:
@@ -316,9 +315,6 @@ jobs:
             COLLECTION_PATH=ansible_collections/${NAMESPACE}/${COLLECTION_NAME}
             COLLECTION_INTEGRATION_PATH=${COLLECTION_PATH}/tests/integration
             COLLECTION_INTEGRATION_TARGETS=${COLLECTION_INTEGRATION_PATH}/targets
-            LOOKUP_HASHI_VAULT_PATH=${COLLECTION_INTEGRATION_TARGETS}/lookup_hashi_vault
-            LOOKUP_HASHI_VAULT_BIN=${LOOKUP_HASHI_VAULT_PATH}/lookup_hashi_vault/files/bin
-            LOOKUP_HASHI_VAULT_VARS=${LOOKUP_HASHI_VAULT_PATH}/lookup_hashi_vault/vars
 
       - name: Check out code
         uses: actions/checkout@v2
@@ -371,6 +367,7 @@ jobs:
 
       - name: Pull Ansible test images
         if: ${{ matrix.docker }}
+        timeout-minutes: 5
         continue-on-error: true
         uses: ./.github/actions/pull-ansible-test-images
         with:

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -267,14 +267,14 @@ jobs:
         run: ./setup.sh -e vault_version=${VAULT_VERSION}
         working-directory: ${{ env.COLLECTION_INTEGRATION_TARGETS }}/setup_localenv_gha
 
-      - name: Run integration test (Vault ${{ env.VAULT_VERSION }})
-        run: ansible-test integration -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --docker ${{ matrix.test_container }} --coverage --docker-network hashi_vault_default
-        working-directory: ${{ env.COLLECTION_PATH }}
+      # - name: Run integration test (Vault ${{ env.VAULT_VERSION }})
+      #   run: ansible-test integration -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --docker ${{ matrix.test_container }} --coverage --docker-network hashi_vault_default
+      #   working-directory: ${{ env.COLLECTION_PATH }}
 
-      - name: Set Vault Version (3)
-        uses: briantist/ezenv@v1
-        with:
-          env: VAULT_VERSION=${{ fromJSON(steps.vault_versions.outputs.versions)[2] }}
+      # - name: Set Vault Version (3)
+      #   uses: briantist/ezenv@v1
+      #   with:
+      #     env: VAULT_VERSION=${{ fromJSON(steps.vault_versions.outputs.versions)[2] }}
 
       - name: Prepare docker dependencies (Vault ${{ env.VAULT_VERSION }})
         run: ./setup.sh -e vault_version=${VAULT_VERSION}

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -164,7 +164,7 @@ jobs:
 
   integration:
     runs-on: ${{ matrix.runner }}
-    name: I (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }}  # | Vault ${{ matrix.vault }})
+    name: I (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }}
     strategy:
       fail-fast: false
       matrix:
@@ -244,7 +244,7 @@ jobs:
         with:
           working-directory: ${{ env.COLLECTION_PATH }}
 
-      - name: Set Vault Version (1)
+      - name: Set Vault Version (first)
         uses: briantist/ezenv@v1
         with:
           env: VAULT_VERSION=${{ fromJSON(steps.vault_versions.outputs.versions)[0] }}
@@ -257,7 +257,7 @@ jobs:
         run: ansible-test integration -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --docker ${{ matrix.test_container }} --coverage --docker-network hashi_vault_default
         working-directory: ${{ env.COLLECTION_PATH }}
 
-      - name: Set Vault Version (2)
+      - name: Set Vault Version (second)
         uses: briantist/ezenv@v1
         with:
           env: VAULT_VERSION=${{ fromJSON(steps.vault_versions.outputs.versions)[1] }}

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -185,8 +185,8 @@ jobs:
           - 3.8
           - 3.9
         vault:
-          - 1.7.3
-          - 1.6.5
+          - latest
+          - 1.7.4
         exclude:
           - ansible: stable-2.9
             python: 3.9

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -267,22 +267,22 @@ jobs:
         run: ./setup.sh -e vault_version=${VAULT_VERSION}
         working-directory: ${{ env.COLLECTION_INTEGRATION_TARGETS }}/setup_localenv_gha
 
-      # - name: Run integration test (Vault ${{ env.VAULT_VERSION }})
-      #   run: ansible-test integration -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --docker ${{ matrix.test_container }} --coverage --docker-network hashi_vault_default
-      #   working-directory: ${{ env.COLLECTION_PATH }}
+      - name: Run integration test (Vault ${{ env.VAULT_VERSION }})
+        run: ansible-test integration -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --docker ${{ matrix.test_container }} --coverage --docker-network hashi_vault_default
+        working-directory: ${{ env.COLLECTION_PATH }}
 
       # - name: Set Vault Version (3)
       #   uses: briantist/ezenv@v1
       #   with:
       #     env: VAULT_VERSION=${{ fromJSON(steps.vault_versions.outputs.versions)[2] }}
 
-      - name: Prepare docker dependencies (Vault ${{ env.VAULT_VERSION }})
-        run: ./setup.sh -e vault_version=${VAULT_VERSION}
-        working-directory: ${{ env.COLLECTION_INTEGRATION_TARGETS }}/setup_localenv_gha
+      # - name: Prepare docker dependencies (Vault ${{ env.VAULT_VERSION }})
+      #   run: ./setup.sh -e vault_version=${VAULT_VERSION}
+      #   working-directory: ${{ env.COLLECTION_INTEGRATION_TARGETS }}/setup_localenv_gha
 
-      - name: Run integration test (Vault ${{ env.VAULT_VERSION }})
-        run: ansible-test integration -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --docker ${{ matrix.test_container }} --coverage --docker-network hashi_vault_default
-        working-directory: ${{ env.COLLECTION_PATH }}
+      # - name: Run integration test (Vault ${{ env.VAULT_VERSION }})
+      #   run: ansible-test integration -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --docker ${{ matrix.test_container }} --coverage --docker-network hashi_vault_default
+      #   working-directory: ${{ env.COLLECTION_PATH }}
 
       # - name: Prepare docker dependencies
       #   run: ./setup.sh -e vault_version=${{ matrix.vault }}
@@ -377,7 +377,9 @@ jobs:
 
       - name: legacy integration - use sample integration_config
         working-directory: ${{ env.COLLECTION_INTEGRATION_PATH }}
-        run: cp "integration_config.yml.sample" "integration_config.yml"
+        run: |
+          cp "integration_config.yml.sample" "integration_config.yml"
+          echo -e "\n\ngithub_token: ${{ secrets.GITHUB_TOKEN }}" >> "integration_config.yml"
 
       - name: legacy integration - venv
         if: ${{ matrix.runner != 'macos-latest' || !matrix.docker }}

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -164,7 +164,7 @@ jobs:
 
   integration:
     runs-on: ${{ matrix.runner }}
-    name: I (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }} | Vault ${{ matrix.vault }})
+    name: I (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }}  # | Vault ${{ matrix.vault }})
     strategy:
       fail-fast: false
       matrix:
@@ -184,9 +184,9 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
-        vault:
-          - latest
-          - 1.7.4
+        # vault:
+        #   - latest
+          # - 1.7.4
         exclude:
           - ansible: stable-2.9
             python: 3.9
@@ -230,6 +230,10 @@ jobs:
         with:
           python-version: 3.8
 
+      - name: Get Vault versions
+        id: vault_versions
+        uses: ./.github/actions/docker-image-versions
+
       - name: Install ansible-base (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
 
@@ -239,14 +243,53 @@ jobs:
         with:
           working-directory: ${{ env.COLLECTION_PATH }}
 
-      - name: Prepare docker dependencies
-        run: ./setup.sh -e vault_version=${{ matrix.vault }}
+      - name: Set Vault Version (1)
+        uses: briantist/ezenv@v1
+        with:
+          env: VAULT_VERSION=${{ fromJSON(steps.vault_versions.outputs.versions)[0]
+
+      - name: Prepare docker dependencies (Vault ${{ env.VAULT_VERSION }})
+        run: ./setup.sh -e vault_version=${VAULT_VERSION}
         working-directory: ${{ env.COLLECTION_INTEGRATION_TARGETS }}/setup_localenv_gha
 
-      - name: Run integration test
-        run: |
-          ansible-test integration -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --docker ${{ matrix.test_container }} --coverage --docker-network hashi_vault_default
+      - name: Run integration test (Vault ${{ env.VAULT_VERSION }})
+        run: ansible-test integration -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --docker ${{ matrix.test_container }} --coverage --docker-network hashi_vault_default
         working-directory: ${{ env.COLLECTION_PATH }}
+
+      - name: Set Vault Version (2)
+        uses: briantist/ezenv@v1
+        with:
+          env: VAULT_VERSION=${{ fromJSON(steps.vault_versions.outputs.versions)[1]
+
+      - name: Prepare docker dependencies (Vault ${{ env.VAULT_VERSION }})
+        run: ./setup.sh -e vault_version=${VAULT_VERSION}
+        working-directory: ${{ env.COLLECTION_INTEGRATION_TARGETS }}/setup_localenv_gha
+
+      - name: Run integration test (Vault ${{ env.VAULT_VERSION }})
+        run: ansible-test integration -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --docker ${{ matrix.test_container }} --coverage --docker-network hashi_vault_default
+        working-directory: ${{ env.COLLECTION_PATH }}
+
+      - name: Set Vault Version (3)
+        uses: briantist/ezenv@v1
+        with:
+          env: VAULT_VERSION=${{ fromJSON(steps.vault_versions.outputs.versions)[2]
+
+      - name: Prepare docker dependencies (Vault ${{ env.VAULT_VERSION }})
+        run: ./setup.sh -e vault_version=${VAULT_VERSION}
+        working-directory: ${{ env.COLLECTION_INTEGRATION_TARGETS }}/setup_localenv_gha
+
+      - name: Run integration test (Vault ${{ env.VAULT_VERSION }})
+        run: ansible-test integration -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --docker ${{ matrix.test_container }} --coverage --docker-network hashi_vault_default
+        working-directory: ${{ env.COLLECTION_PATH }}
+
+      # - name: Prepare docker dependencies
+      #   run: ./setup.sh -e vault_version=${{ matrix.vault }}
+      #   working-directory: ${{ env.COLLECTION_INTEGRATION_TARGETS }}/setup_localenv_gha
+
+      # - name: Run integration test
+      #   run: |
+      #     ansible-test integration -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --docker ${{ matrix.test_container }} --coverage --docker-network hashi_vault_default
+      #   working-directory: ${{ env.COLLECTION_PATH }}
 
         # ansible-test support producing code coverage data
       - name: Generate coverage report
@@ -256,7 +299,7 @@ jobs:
       - name: Upload ${{ github.job }} coverage reports
         uses: actions/upload-artifact@v2
         with:
-          name: coverage=${{ github.job }}=ansible_${{ matrix.ansible }}=${{ matrix.python }}=${{ matrix.vault }}=data
+          name: coverage=${{ github.job }}=ansible_${{ matrix.ansible }}=${{ matrix.python }}=data
           path: ${{ env.COLLECTION_PATH }}/tests/output/reports/
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -184,9 +184,6 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
-        # vault:
-        #   - latest
-          # - 1.7.4
         exclude:
           - ansible: stable-2.9
             python: 3.9
@@ -234,7 +231,9 @@ jobs:
         id: vault_versions
         uses: ./.github/actions/docker-image-versions
         with:
+          num_major_versions: 1
           num_minor_versions: 2
+          num_micro_versions: 1
 
       - name: Install ansible-base (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
@@ -270,28 +269,6 @@ jobs:
       - name: Run integration test (Vault ${{ env.VAULT_VERSION }})
         run: ansible-test integration -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --docker ${{ matrix.test_container }} --coverage --docker-network hashi_vault_default
         working-directory: ${{ env.COLLECTION_PATH }}
-
-      # - name: Set Vault Version (3)
-      #   uses: briantist/ezenv@v1
-      #   with:
-      #     env: VAULT_VERSION=${{ fromJSON(steps.vault_versions.outputs.versions)[2] }}
-
-      # - name: Prepare docker dependencies (Vault ${{ env.VAULT_VERSION }})
-      #   run: ./setup.sh -e vault_version=${VAULT_VERSION}
-      #   working-directory: ${{ env.COLLECTION_INTEGRATION_TARGETS }}/setup_localenv_gha
-
-      # - name: Run integration test (Vault ${{ env.VAULT_VERSION }})
-      #   run: ansible-test integration -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --docker ${{ matrix.test_container }} --coverage --docker-network hashi_vault_default
-      #   working-directory: ${{ env.COLLECTION_PATH }}
-
-      # - name: Prepare docker dependencies
-      #   run: ./setup.sh -e vault_version=${{ matrix.vault }}
-      #   working-directory: ${{ env.COLLECTION_INTEGRATION_TARGETS }}/setup_localenv_gha
-
-      # - name: Run integration test
-      #   run: |
-      #     ansible-test integration -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --docker ${{ matrix.test_container }} --coverage --docker-network hashi_vault_default
-      #   working-directory: ${{ env.COLLECTION_PATH }}
 
         # ansible-test support producing code coverage data
       - name: Generate coverage report

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ See [the CI configuration](https://github.com/ansible-collections/community.hash
 
 ## Tested with Vault
 
-We currently test against the latest two minor versions of Vault major version `1`. The patch version within each minor will be updated periodically.
+We currently test against the latest patch version within the latest two minor versions of the latest major version of Vault. Put another way, we test against version `Z.{Z|Y}.Z`. For example as of this writing, Vault is on major version `1`, with the latest two minors being `8` and `7`. So we'll test Vault `1.8.Z` and `1.7.Z` where `Z` is the latest patch within those versions.
 
 We do not test against any versions of Vault with major version `0`.
 
-If/when a new major version of Vault is released, we'll revisit which versions to test against.
+If/when a new major version of Vault is released, we'll revisit which and how many versions to test against.
 
 The decision of which version(s) of Vault to test against is still somewhat in flux, as we try to balance wide testing with CI execution time and resources.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Browsing the [**latest** collection documentation](https://docs.ansible.com/ansi
 
 Browsing the [**devel** collection documentation](https://docs.ansible.com/ansible/devel/collections/community/hashi_vault) shows docs for the _latest version released on Galaxy_.
 
-If you use the Ansible package and don't update collections independently, use **latest**, if you install or update this collection directly from Galaxy, use **devel**. If you are looking to contribute, use **devel**.
+We also separately publish [**latest commit** collection documentation](https://community-hashi-vault-main.surge.sh) which shows docs for the _Latest commit in the `main` branch_.
+
+If you use the Ansible package and don't update collections independently, use **latest**, if you install or update this collection directly from Galaxy, use **devel**. If you are looking to contribute, use **latest commit**.
 ## Tested with Ansible
 
 * 2.9
@@ -24,7 +26,7 @@ See [the CI configuration](https://github.com/ansible-collections/community.hash
 
 We currently test against the latest patch version within the latest two minor versions of the latest major version of Vault. Put another way, we test against version `Z.{Z|Y}.Z`. For example as of this writing, Vault is on major version `1`, with the latest two minors being `8` and `7`. So we'll test Vault `1.8.Z` and `1.7.Z` where `Z` is the latest patch within those versions.
 
-We do not test against any versions of Vault with major version `0`.
+We do not test against any versions of Vault with major version `0` or against pre-release/release candidate (RC) versions.
 
 If/when a new major version of Vault is released, we'll revisit which and how many versions to test against.
 

--- a/docs/docsite/rst/contributor_guide.rst
+++ b/docs/docsite/rst/contributor_guide.rst
@@ -104,6 +104,10 @@ To get started quickly without having to set anything else, you can use legacy m
 
 That file has everything configured to be able to run the integration tests and have them set up the dependencies for you.
 
+.. warning::
+
+  Legacy mode uses the GitHub API to figure out the latest version of HashiCorp Vault. This API has a `strict rate limit <https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting>`_ on anonymous requests and it's easy to hit that limit. You may set `github_token` within `integration_config.yml` to provide a token to use, which will give a much higher request, however if you find yourself hitting the limit, it's probably easier to instead set `vault_version` to a specific version, which avoids the API call altogether.
+
 You will also need the following additional Ansible collections:
 
 * `community.crypto <https://galaxy.ansible.com/community/crypto>`_
@@ -192,7 +196,7 @@ Customization
 
 ``setup.sh`` passes any additional params you send it to the ``ansible-playbook`` command it calls, so you can customize variables with the standard ``--extra-vars`` (or ``-e``) option. There are many advanced scenarios possible, but a few things you might want to override:
 
-* ``vault_version`` -- can target any version of Vault for which a docker container exists
+* ``vault_version`` -- can target any version of Vault for which a docker container exists (this is the container's tag), defaults to ``latest``
 * ``docker_compose`` (defaults to ``clean`` but could be set to ``up``, ``down``, or ``none``)
    * ``up`` -- similar to running ``docker-compose up`` (no op if the project is running as it should)
    * ``down`` -- similar to ``docker-compose down`` (destroys the project)

--- a/docs/docsite/rst/contributor_guide.rst
+++ b/docs/docsite/rst/contributor_guide.rst
@@ -106,7 +106,7 @@ That file has everything configured to be able to run the integration tests and 
 
 .. warning::
 
-  Legacy mode uses the GitHub API to figure out the latest version of HashiCorp Vault. This API has a `strict rate limit <https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting>`_ on anonymous requests and it's easy to hit that limit. You may set `github_token` within `integration_config.yml` to provide a token to use, which will give a much higher request, however if you find yourself hitting the limit, it's probably easier to instead set `vault_version` to a specific version, which avoids the API call altogether.
+  Legacy mode uses the GitHub API to figure out the latest version of HashiCorp Vault. This API has a `strict rate limit <https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting>`_ on anonymous requests and it's easy to hit that limit. You may set ``github_token`` within ``integration_config.yml`` to provide a token to use, which will give a much higher request, however if you find yourself hitting the limit, it's probably easier to instead set ``vault_version`` to a specific version, which avoids the API call altogether.
 
 You will also need the following additional Ansible collections:
 

--- a/docs/docsite/rst/contributor_guide.rst
+++ b/docs/docsite/rst/contributor_guide.rst
@@ -89,9 +89,9 @@ If you have contributed to this collection or to the ``hashi_vault`` lookup plug
 
 .. note::
 
-  Legacy mode is not recommended because a new Vault server and proxy server will be downloaded, set up, configured, and/or uninstalled, for every *target*. Traditionally, we've only had one target, and so it was a good way to go, but that's no longer going to be the case. This will make it slower and slower as you'll incur the overhead on every target, in every run.
+  Legacy mode is not recommended because a new Vault server and proxy server will be downloaded, set up, configured, and/or uninstalled, for every *target*. Historically, we only had one target, and so it was a good way to go, but that's no longer true. This will make it slower and slower as more targets are added because you will incur the overhead on every target, in every run.
 
-  Skip to :ref:`ansible_collections.community.hashi_vault.docsite.contributor_guide.localenv_docker` for a method that's nearly as easy as legacy mode, and far more efficient (docker-compose).
+  Skip to :ref:`ansible_collections.community.hashi_vault.docsite.contributor_guide.localenv_docker` for a method that is nearly as easy as legacy mode, and far more efficient (docker-compose).
 
 Legacy mode
 ^^^^^^^^^^^
@@ -106,7 +106,7 @@ That file has everything configured to be able to run the integration tests and 
 
 .. warning::
 
-  Legacy mode uses the GitHub API to figure out the latest version of HashiCorp Vault. This API has a `strict rate limit <https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting>`_ on anonymous requests and it's easy to hit that limit. You may set ``github_token`` within ``integration_config.yml`` to provide a token to use, which will give a much higher request, however if you find yourself hitting the limit, it's probably easier to instead set ``vault_version`` to a specific version, which avoids the API call altogether.
+  Legacy mode uses the GitHub API to figure out the latest version of HashiCorp Vault. This API has a `strict rate limit <https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting>`_ on anonymous requests and it's easy to hit that limit. You may set ``github_token`` within ``integration_config.yml`` to provide a token to use, which will give a much higher limit, however if you find yourself hitting the limit, it's probably easier to instead set ``vault_version`` to a specific version, which avoids the API call altogether.
 
 You will also need the following additional Ansible collections:
 
@@ -127,7 +127,7 @@ Running legacy mode tests in a controlled python virtual environment (**not reco
 
 .. warning::
 
-  In legacy mode, your system packages may be manipulated by running locally or in a venv.
+  In legacy mode, your system packages may be manipulated by running locally or in a venv (not in docker).
 
 If you must use legacy mode testing, you can make it more efficient by limiting your test run to the specific target needed, to avoid the overhead of creating and destroying the dependencies for each target. For example:
 

--- a/docs/docsite/rst/localenv_developer_guide.rst
+++ b/docs/docsite/rst/localenv_developer_guide.rst
@@ -40,7 +40,7 @@ Relevant ``integration_config.yml`` variables
   "``vault_test_server_http``", "``http://myvault:8200``", "The full HTTP URL of your Vault test server."
   "``vault_test_server_https``", "``https://myvault:8300``", "The full HTTPS URL of your Vault test server."
   "``vault_dev_root_token_id``", "``3ee9a1f7-f115-4f7c-90a3-d3c73361bcb5``", "The root token used to authenticate to Vault."
-  "``vault_version``", "``1.7.3``", "The desired version of Vault to download (only used by legacy setup)."
+  "``vault_version``", "``1.7.3``", "The desired version of Vault to download (only used by legacy setup). Can use the value ``latest``."
   "``vault_integration_legacy``", "``false``", "When ``true`` legacy integration will be used (see legacy section)."
   "``vault_cert_content``", "``-----BEGIN CERTIFICATE-----<snip>``", "The public cert of the CA that signed the cert used for Vault's TLS listener (or the cert itself if self-signed)."
 

--- a/tests/integration/integration_config.yml.sample
+++ b/tests/integration/integration_config.yml.sample
@@ -2,8 +2,9 @@
 # for best results, consider a different localenv setup.
 # See the additional documentation at https://docs.ansible.com/ansible/devel/collections/community/hashi_vault/
 ---
+# With legacy integration mode, vault_version should be a specific version, or the special value "latest".
+vault_version: latest
 vault_integration_legacy: true
-vault_version: 1.7.3
 
 vault_dev_root_token_id: 47542cbc-6bf8-4fba-8eda-02e0a0d29a0a
 

--- a/tests/integration/targets/setup_localenv_docker/defaults/main.yml
+++ b/tests/integration/targets/setup_localenv_docker/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-vault_version: '1.7.3'
+vault_version: latest
 vault_dev_root_token_id: 47542cbc-6bf8-4fba-8eda-02e0a0d29a0a
 
 docker_compose: clean
@@ -29,4 +29,4 @@ vault_config_output: '{{ output_dir }}/vault_config'
 vault_cert_file: '{{ vault_config_output }}/cert.pem'
 vault_key_file: '{{ vault_config_output }}/key.pem'
 
-vault_crypto_force: False
+vault_crypto_force: false

--- a/tests/integration/targets/setup_vault_server_download/defaults/main.yml
+++ b/tests/integration/targets/setup_vault_server_download/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 vault_ansible_arch_table:
-  'x86_64': 'amd64' # Linux
-  'amd64': 'amd64' # FreeBSD
+  'x86_64': 'amd64'   # Linux
+  'amd64': 'amd64'    # FreeBSD
   'i386': '386'
 
 vault_arch: "{{ vault_ansible_arch_table[ansible_architecture] }}"
@@ -13,3 +13,5 @@ vault_uri: 'https://releases.hashicorp.com/vault/{{ vault_version }}/{{ vault_sl
 vault_cmd: '{{ vault_bin }}/vault'
 
 vault_server_download_force: False
+
+vault_releases_url: https://api.github.com/repos/hashicorp/vault/releases

--- a/tests/integration/targets/setup_vault_server_download/tasks/latest.yml
+++ b/tests/integration/targets/setup_vault_server_download/tasks/latest.yml
@@ -1,10 +1,17 @@
 ---
-- name: Get the list of Vault releases
-  uri:
-    url: '{{ vault_releases_url }}'
-  register: vault_releases
-  no_log: true
-  # this is no_log because the output is large, there are no secrets there
+- block:
+    - name: Get the list of Vault releases
+      uri:
+        url: '{{ vault_releases_url }}'
+      register: vault_releases
+      no_log: true
+      # this is no_log because the output is large, there are no secrets there
+  rescue:
+      # but if it fails, let's do it again without no_log so we can see what happened
+    - name: Get the list of Vault releases
+      uri:
+        url: '{{ vault_releases_url }}'
+      register: vault_releases
 
   # this is a little bit naive; we're using the latest published_at as a
   # proxy for latest version; it's possible for that not to be correct.

--- a/tests/integration/targets/setup_vault_server_download/tasks/latest.yml
+++ b/tests/integration/targets/setup_vault_server_download/tasks/latest.yml
@@ -6,6 +6,8 @@
   no_log: true
   # this is no_log because the output is large, there are no secrets there
 
+  # this is a little bit naive; we're using the latest published_at as a
+  # proxy for latest version; it's possible for that not to be correct.
 - name: Get the latest non-pre-release version
   set_fact:
     vault_version: "{{

--- a/tests/integration/targets/setup_vault_server_download/tasks/latest.yml
+++ b/tests/integration/targets/setup_vault_server_download/tasks/latest.yml
@@ -1,0 +1,19 @@
+---
+- name: Get the list of Vault releases
+  uri:
+    url: '{{ vault_releases_url }}'
+  register: vault_releases
+  no_log: true
+  # this is no_log because the output is large, there are no secrets there
+
+- name: Get the latest non-pre-release version
+  set_fact:
+    vault_version: "{{
+        vault_releases.json
+        | selectattr('draft', 'equalto', False)
+        | selectattr('prerelease', 'equalto', False)
+        | sort(attribute='published_at', reverse=True)
+        | map(attribute='name')
+        | first
+        | replace('v', '')
+      }}"

--- a/tests/integration/targets/setup_vault_server_download/tasks/latest.yml
+++ b/tests/integration/targets/setup_vault_server_download/tasks/latest.yml
@@ -3,11 +3,21 @@
     - name: Get the list of Vault releases
       uri:
         url: '{{ vault_releases_url }}'
+        headers: "{{
+            {'authorization': 'Bearer ' ~ github_token} if github_token is defined else omit
+          }}"
       register: vault_releases
+      until: >-
+        vault_releases is success
+        or vault_releases.status != 403
+        or (vault_releases.json is defined and vault_releases.json.message | default('')) is not search('^API rate limit exceeded')
+      retries: 10
+      delay: 3
       no_log: true
-      # this is no_log because the output is large, there are no secrets there
+      # this is no_log because of the possible GitHub token, and because the output is large
   rescue:
-      # but if it fails, let's do it again without no_log so we can see what happened
+      # but if it fails, let's do it again without no_log (and with no token) so we can see what happened.
+      # without the token we might not hit the same problem, but it's worth a try.
     - name: Get the list of Vault releases
       uri:
         url: '{{ vault_releases_url }}'

--- a/tests/integration/targets/setup_vault_server_download/tasks/main.yml
+++ b/tests/integration/targets/setup_vault_server_download/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Determine latest Vault version if not specified
+  when: >-
+    vault_version is not defined
+    or vault_version == 'latest'
+  include_tasks: latest.yml
+
 - name: "Check if vault binary exists"
   stat:
     path: '{{ vault_cmd }}'
@@ -15,6 +21,7 @@
       file:
         path: '{{ vault_bin }}'
         state: directory
+        mode: u+rwx
 
     - name: 'Download vault binary'
       get_url:
@@ -45,8 +52,8 @@
             # by assuming python3 here we're probably condeming this to not work on older Ubuntu/Debian (from like 2014?)
             # but the alternative is probably reimplementing parts of interpreter_discovery.py
             ansible_python_interpreter: "{{
-              '/usr/bin/python3' if ansible_distribution in ['Ubuntu', 'Debian'] else ansible_python.executable
-            }}"
+                '/usr/bin/python3' if ansible_distribution in ['Ubuntu', 'Debian'] else ansible_python.executable
+              }}"
           package:
             name: unzip
           when: ansible_distribution != "MacOSX"  # unzip already installed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updating the version of Vault to test against has been a manual process. I'm trying to move toward the pattern of integration tests defaulting to the latest non-prelease Version of Vault (single version) when run locally.

For CI, I'll continue testing the latest two minor versions, as described in the README (and clarified further in this PR). That's now automatic, and finding the versions is done through a custom GitHub action via a Python script, which is configurable so we can easily change which and how many versions of Vault to test against.

So the integration tests now run twice in each job, rather than being matrixed with Vault version. It removes a little bit of parallelism but I think that's a benefit because the limit of active jobs in GHA was already limiting. At least within the same job, the Ansible test images have already been pulled, so we're saving some time on initialization. Setting the up a different Vault test container only takes about 10s.

This should have resulted in much better overall CI time, but I continue to be plagued by the fact that the 2.9 integration tests always run last, and they take the longest (the test images are much bigger, and take longer to pull, and 2.9 just plain runs slower in general). 

I did experiment with changing the order in the matrix to see if I could get GitHub to run them in a different order, but it doesn't work. They _display_ in a different order, but run in the same order, so 🤷‍♂️.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test/CI Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
tests/integration

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
N/A
