### PR TITLE
update reqirements for 2.9 hcloud hvac conflict

### DIFF
--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -11,4 +11,5 @@ urllib3 >= 1.15, <2.0.0 ; python_version < '3.6' # https://urllib3.readthedocs.i
 # this is for 2.9 only, because the version pre-installed in the default test container in 2.9
 # has a constraint for requests that conflicts with hvac >= 0.11.1
 # version chosen here is arbitrary, latest at the time of setting, we're just trying to avoid conflicting constraints
-hcloud >= 1.16.0
+hcloud >= 1.16.0 ; python_version >= '3.5'
+hcloud < 1.13.0  ; python_version == '2.7'

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -5,3 +5,10 @@ hvac >= 0.10.6 ; python_version >= '3.6'
 # these should be satisfied naturally by the requests versions required by hvac anyway
 urllib3 >= 1.15 ; python_version >= '3.6' # we need raise_on_status for retry support to raise the correct exceptions https://github.com/urllib3/urllib3/blob/main/CHANGES.rst#115-2016-04-06
 urllib3 >= 1.15, <2.0.0 ; python_version < '3.6' # https://urllib3.readthedocs.io/en/latest/v2-roadmap.html#optimized-for-python-3-6
+
+# TODO: remove when 2.9 support is dropped
+# we don't use or care about hcloud
+# this is for 2.9 only, because the version pre-installed in the default test container in 2.9
+# has a constraint for requests that conflicts with hvac >= 0.11.1
+# version chosen here is arbitrary, latest at the time of setting, we're just trying to avoid conflicting constraints
+hcloud >= 1.16.0

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -10,6 +10,6 @@ urllib3 >= 1.15, <2.0.0 ; python_version < '3.6' # https://urllib3.readthedocs.i
 # we don't use or care about hcloud
 # this is for 2.9 only, because the version pre-installed in the default test container in 2.9
 # has a constraint for requests that conflicts with hvac >= 0.11.1
-# version chosen here is arbitrary, latest at the time of setting, we're just trying to avoid conflicting constraints
+# versions chosen here are arbitrary, latest usable at the time of setting, we're just trying to avoid conflicting constraints
 hcloud >= 1.16.0 ; python_version >= '3.5'
-hcloud < 1.13.0  ; python_version == '2.7'
+hcloud == 1.13.0  ; python_version == '2.7'

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -12,4 +12,4 @@ urllib3 >= 1.15, <2.0.0 ; python_version < '3.6' # https://urllib3.readthedocs.i
 # has a constraint for requests that conflicts with hvac >= 0.11.1
 # versions chosen here are arbitrary, latest usable at the time of setting, we're just trying to avoid conflicting constraints
 hcloud >= 1.16.0 ; python_version >= '3.5'
-hcloud == 1.13.0  ; python_version == '2.7'
+hcloud >= 1.12.0, < 1.13.0  ; python_version == '2.7'

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -11,4 +11,5 @@ urllib3 >= 1.15, <2.0.0 ; python_version < '3.6' # https://urllib3.readthedocs.i
 # this is for 2.9 only, because the version pre-installed in the default test container in 2.9
 # has a constraint for requests that conflicts with hvac >= 0.11.1
 # version chosen here is arbitrary, latest at the time of setting, we're just trying to avoid conflicting constraints
-hcloud >= 1.16.0
+hcloud >= 1.16.0 ; python_version >= '3.5'
+hcloud < 1.13.0  ; python_version == '2.7'

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -10,6 +10,6 @@ urllib3 >= 1.15, <2.0.0 ; python_version < '3.6' # https://urllib3.readthedocs.i
 # we don't use or care about hcloud
 # this is for 2.9 only, because the version pre-installed in the default test container in 2.9
 # has a constraint for requests that conflicts with hvac >= 0.11.1
-# versions chosen here are arbitrary, latest uable at the time of setting, we're just trying to avoid conflicting constraints
+# versions chosen here are arbitrary, latest usable at the time of setting, we're just trying to avoid conflicting constraints
 hcloud >= 1.16.0 ; python_version >= '3.5'
-hcloud < 1.13.0  ; python_version == '2.7'
+hcloud == 1.13.0  ; python_version == '2.7'

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -5,3 +5,10 @@ hvac >= 0.10.6 ; python_version >= '3.6'
 # these should be satisfied naturally by the requests versions required by hvac anyway
 urllib3 >= 1.15 ; python_version >= '3.6' # we need raise_on_status for retry support to raise the correct exceptions https://github.com/urllib3/urllib3/blob/main/CHANGES.rst#115-2016-04-06
 urllib3 >= 1.15, <2.0.0 ; python_version < '3.6' # https://urllib3.readthedocs.io/en/latest/v2-roadmap.html#optimized-for-python-3-6
+
+# TODO: remove when 2.9 support is dropped
+# we don't use or care about hcloud
+# this is for 2.9 only, because the version pre-installed in the default test container in 2.9
+# has a constraint for requests that conflicts with hvac >= 0.11.1
+# version chosen here is arbitrary, latest at the time of setting, we're just trying to avoid conflicting constraints
+hcloud >= 1.16.0

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -12,4 +12,4 @@ urllib3 >= 1.15, <2.0.0 ; python_version < '3.6' # https://urllib3.readthedocs.i
 # has a constraint for requests that conflicts with hvac >= 0.11.1
 # versions chosen here are arbitrary, latest usable at the time of setting, we're just trying to avoid conflicting constraints
 hcloud >= 1.16.0 ; python_version >= '3.5'
-hcloud == 1.13.0  ; python_version == '2.7'
+hcloud >= 1.12.0, < 1.13.0  ; python_version == '2.7'

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -10,6 +10,6 @@ urllib3 >= 1.15, <2.0.0 ; python_version < '3.6' # https://urllib3.readthedocs.i
 # we don't use or care about hcloud
 # this is for 2.9 only, because the version pre-installed in the default test container in 2.9
 # has a constraint for requests that conflicts with hvac >= 0.11.1
-# version chosen here is arbitrary, latest at the time of setting, we're just trying to avoid conflicting constraints
+# versions chosen here are arbitrary, latest uable at the time of setting, we're just trying to avoid conflicting constraints
 hcloud >= 1.16.0 ; python_version >= '3.5'
 hcloud < 1.13.0  ; python_version == '2.7'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`hvac 0.11.1` upped the constraint for `requests` to be `>= 2.25.1`. That ends up conflicting with the constraints for `hcloud` which is pre-installed in the default test container in 2.9, causing `ansible-test` to throw an error and fail.

This PR declares `hcloud` in our requirements with a newer version. It's an unfortunate workaround, since we don't really need it at all.

Newer versions of the default container don't contain `hcloud` at all, but we'll be installing them in there anyway since we can't do this selectively.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
tests/

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
https://github.com/hvac/hvac/pull/741
