### PR TITLE
docs - docs-build all with approval

### DIFF
--- a/.github/workflows/docs-full.yml
+++ b/.github/workflows/docs-full.yml
@@ -1,14 +1,9 @@
 ---
-name: Collection Docs
+name: Collection Docs (Full)
 concurrency: docs-${{ github.ref }}
 on:
-  push:
-    branches:
-      - main
   pull_request_target:
-    types: [opened, synchronize, reopened, closed]
-  schedule:
-    - cron: '0 13 * * *'
+    types: [opened, synchronize, reopened]
 
 env:
   NAMESPACE: community
@@ -16,74 +11,12 @@ env:
   NOT_A_FORK: ${{ github.repository == 'ansible-collections/community.hashi_vault' }}
 
 jobs:
-  unpublish:
-    name: Clean up closed PR
-    if: >-
-      github.event_name == 'pull_request_target'
-      && github.event.action == 'closed'
-      && github.repository == 'ansible-collections/community.hashi_vault'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up env vars
-        uses: briantist/ezenv@v1
-        with:
-          env: |
-            SITE_STUB=community-hashi-vault
-            SITE_NAME_MAIN=${SITE_STUB}-main
-            SITE_NAME=${SITE_STUB}-pr${{ github.event.number }}
-
-      - name: Install Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14
-
-      - name: Install Surge
-        run: npm install -g surge
-
-      - name: Unpublish site
-        continue-on-error: true
-        run: surge teardown ${SITE_NAME}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
-
-      - name: Look for existing comment
-        id: fc
-        uses: peter-evans/find-comment@v1
-        with:
-          issue-number: ${{ github.event.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: "##Docs Build"
-
-      - name: Post a comment on a merged PR
-        if: github.event.pull_request.merged == true && steps.fc.outputs.comment-id
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ github.event.number }}
-          edit-mode: replace
-          body: |
-            ##Docs Build 📝
-
-            Thank you for contribution!✨
-
-            This PR has been merged and the docs are now incorporated into `main`:
-            https://${{ env.SITE_NAME_MAIN }}.surge.sh
-
-      - name: Post a comment on a closed PR
-        if: github.event.pull_request.merged == false && steps.fc.outputs.comment-id
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ github.event.number }}
-          edit-mode: replace
-          body: |
-            ##Docs Build 📝
-
-            This PR is closed and any previously published docsite has been unpublished.
-
   docs:
+    environment: docs-build
     name: Collection Docs Lint & Build
-    if: >-
-      github.event_name != 'pull_request_target'
-      || github.event.action != 'closed'
+    # if: >-
+    #   github.event_name != 'pull_request_target'
+    #   || github.event.action != 'closed'
     runs-on: ubuntu-latest
     steps:
       - name: Set up env vars
@@ -121,37 +54,39 @@ jobs:
           ANSIBLE_COLLECTIONS_PATH: ${{ github.workspace }}
         run: ${DOCS_PREVIEW}/build.sh
 
-      - name: Save the base build & hash # and discard the build
+      - name: Save the base build & hash and discard the build
         run: |
           echo "BASE_DOCS_HASH=${{ hashFiles(env.HTML) }}" >> $GITHUB_ENV
           mkdir -p "${BASE_DOCS_RENDERED}"
           rsync -avc --delete-after "${HTML}" "${BASE_DOCS_RENDERED}"
+
+          rm -rf "${COLLECTION_PATH}"
 
 
       ######## IMPORTANT
       # Do not change these checkout and apply tasks lightly, we only want the docs from the PR side.
       # Please read ALL of this document before changing these:
       # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-      - name: Check out PR to temp location
-        if: github.event_name == 'pull_request_target'
+      - name: Check out PR
+        # if: github.event_name == 'pull_request_target'
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          path: __pr
+          path: ${{ env.COLLECTION_PATH }}
 
-      - name: Apply docs changes from PR
-        if: github.event_name == 'pull_request_target'
-        working-directory: ${{ env.COLLECTION_PATH }}
-        run: |
-          rsync -avc --delete-after "${{ github.workspace }}/__pr/docs/docsite/" docs/docsite/
-          rm -rf "${{ github.workspace }}/__pr"
+      # - name: Apply docs changes from PR
+      #   if: github.event_name == 'pull_request_target'
+      #   working-directory: ${{ env.COLLECTION_PATH }}
+      #   run: |
+      #     rsync -avc --delete-after "${{ github.workspace }}/__pr/docs/docsite/" docs/docsite/
+      #     rm -rf "${{ github.workspace }}/__pr"
 
       - name: Lint Collection Docs
         working-directory: ${{ env.COLLECTION_PATH }}
         run: antsibull-lint collection-docs -v .
 
       - name: Build the preview docs (${{ github.head_ref }})
-        if: github.event_name == 'pull_request_target'
+        # if: github.event_name == 'pull_request_target'
         env:
           ANSIBLE_COLLECTIONS_PATH: ${{ github.workspace }}
         run: |
@@ -160,7 +95,7 @@ jobs:
           ${DOCS_PREVIEW}/build.sh
 
       - name: Save the head hash
-        if: github.event_name == 'pull_request_target'
+        # if: github.event_name == 'pull_request_target'
         run: |
           echo "HEAD_DOCS_HASH=${{ hashFiles(env.HTML) }}" >> $GITHUB_ENV
           mkdir -p "${PR_DOCS_RENDERED}"
@@ -224,7 +159,7 @@ jobs:
         run: surge teardown ${SITE_NAME}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
 
       - name: Look for existing comment
-        if: github.event_name == 'pull_request_target'
+        # if: github.event_name == 'pull_request_target'
         id: fc
         uses: peter-evans/find-comment@v1
         with:

--- a/.github/workflows/docs-full.yml
+++ b/.github/workflows/docs-full.yml
@@ -12,11 +12,11 @@ env:
 
 jobs:
   docs:
+    # This workflow must be subject to pre-review and approval before running.
+    # This is accomplished with the "docs-build" GitHub deployment environment in the repo.
+    # See comments on the "Check out PR" step as well.
     environment: docs-build
     name: Collection Docs Lint & Build
-    # if: >-
-    #   github.event_name != 'pull_request_target'
-    #   || github.event.action != 'closed'
     runs-on: ubuntu-latest
     steps:
       - name: Set up env vars
@@ -64,29 +64,22 @@ jobs:
 
 
       ######## IMPORTANT
-      # Do not change these checkout and apply tasks lightly, we only want the docs from the PR side.
+      # This workflow executes code from the PR, in a privileged workflow.
+      # This workflow must be subject to pre-review and approval before running.
+      # This is accomplished with the "docs-build" GitHub deployment environment in the repo.
       # Please read ALL of this document before changing these:
       # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
       - name: Check out PR
-        # if: github.event_name == 'pull_request_target'
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: ${{ env.COLLECTION_PATH }}
-
-      # - name: Apply docs changes from PR
-      #   if: github.event_name == 'pull_request_target'
-      #   working-directory: ${{ env.COLLECTION_PATH }}
-      #   run: |
-      #     rsync -avc --delete-after "${{ github.workspace }}/__pr/docs/docsite/" docs/docsite/
-      #     rm -rf "${{ github.workspace }}/__pr"
 
       - name: Lint Collection Docs
         working-directory: ${{ env.COLLECTION_PATH }}
         run: antsibull-lint collection-docs -v .
 
       - name: Build the preview docs (${{ github.head_ref }})
-        # if: github.event_name == 'pull_request_target'
         env:
           ANSIBLE_COLLECTIONS_PATH: ${{ github.workspace }}
         run: |
@@ -95,7 +88,6 @@ jobs:
           ${DOCS_PREVIEW}/build.sh
 
       - name: Save the head hash
-        # if: github.event_name == 'pull_request_target'
         run: |
           echo "HEAD_DOCS_HASH=${{ hashFiles(env.HTML) }}" >> $GITHUB_ENV
           mkdir -p "${PR_DOCS_RENDERED}"
@@ -159,7 +151,6 @@ jobs:
         run: surge teardown ${SITE_NAME}.surge.sh --token ${{ secrets.SURGE_TOKEN }}
 
       - name: Look for existing comment
-        # if: github.event_name == 'pull_request_target'
         id: fc
         uses: peter-evans/find-comment@v1
         with:
@@ -195,7 +186,7 @@ jobs:
 
             Thank you for contribution!✨
 
-            The docs for **this PR** have been published here:
+            The **full** docs for **this PR** have been published here:
             https://${{ env.SITE_NAME }}.surge.sh
 
             You can compare to the docs for the `main` branch here:

--- a/.github/workflows/docs-full.yml
+++ b/.github/workflows/docs-full.yml
@@ -1,6 +1,8 @@
 ---
 name: Collection Docs (Full)
-concurrency: docs-${{ github.ref }}
+concurrency:
+  group: docs-full-${{ github.ref }}
+  cancel-in-progress: true
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -260,7 +260,7 @@ jobs:
 
             Thank you for contribution!✨
 
-            The docs for **this PR** have been published here:
+            The docs for **this PR** have been published here (docsite changes only):
             https://${{ env.SITE_NAME }}.surge.sh
 
             You can compare to the docs for the `main` branch here:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,8 @@
 ---
 name: Collection Docs
-concurrency: docs-${{ github.ref }}
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
 on:
   push:
     branches:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This adds a new workflow that uses a custom github "environment" so that running this workflow requires approval.
This workflow is very similar to the existing docs build, the difference is that it uses the _entire_ PR contents, and not just the `docs/docsite`.

As described in #138 , that's a security risk when running via `pull_request_target`, because the workflow has access to secrets and an elevated GitHub token.

That's where pre-approval comes in: this workflow will not run until someone has reviewed the PR and then allows this workflow to run.

The existing docsite-only workflow will still run, automatically, so PR authors can get quick feedback on those changes, and (after review) full docs rendering that includes plugin and module doc changes is still possible before a PR is merged, to the benefit of both PR authors and reviewers/maintainers.

## See it in action
A sample PR against this branch can be seen in #149 .

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs build

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
This is not necessarily in the best end state. It is a lot of copy-paste from the other docs-build. Many of these steps should be generalized out and made into composite actions, and then they can be DRYed up a but. But I feel the advantage of getting this in place early outweighs some duplication. It will be cleaned up over time.