### PR TITLE
docs - fix concurrency group name

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -5,10 +5,12 @@ on:
     paths-ignore:
       - 'docs/**'
       - '.github/workflows/docs.yml'
+      - '.github/workflows/docs-full.yml'
   pull_request:
     paths-ignore:
       - 'docs/**'
       - '.github/workflows/docs.yml'
+      - '.github/workflows/docs-full.yml'
   schedule:
     - cron: '0 14 * * *'
 env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 ---
 name: Collection Docs
 concurrency:
-  group: docs-${{ github.ref }}
+  group: docs-${{ github.ref }}-${{ github.event_name }}-${{ github.event.action }}
   cancel-in-progress: true
 on:
   push:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In #150 , added concurrency settings with cancel of existing. Problem is that on merging a PR, the workflow is run twice, once for the PR close and once for the push to main; this is expected and necessary. But since the concurrency group only contains the ref, then one of those two events ends up cancelled.

Also adding a forgotten exclude so that changes to the docs full workflow don't trigger full CI.

This change includes the event name and action in the concurrency group, to ensure things work correctly.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
N/A