### PR TITLE
auth: add env and ini var for mount_point option

### DIFF
--- a/changelogs/fragments/pr-171-envvar-for-mount-point.yaml
+++ b/changelogs/fragments/pr-171-envvar-for-mount-point.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- auth methods - Add support for configuring the ``mount_point`` auth method option in plugins via the ``HASHI_VAULT_MOUNT_POINT`` environment variable, ``ansible_hashi_vault_mount_point`` ansible variable, or ``mount_point`` INI section (https://github.com/ansible-collections/community.hashi_vault/pull/171).

--- a/plugins/doc_fragments/auth.py
+++ b/plugins/doc_fragments/auth.py
@@ -122,6 +122,17 @@ class ModuleDocFragment(object):
         vars:
           - name: ansible_hashi_vault_auth_method
             version_added: 1.2.0
+      mount_point:
+        env:
+          - name: ANSIBLE_HASHI_VAULT_MOUNT_POINT
+            version_added: 1.5.0
+        ini:
+          - section: hashi_vault_collection
+            key: mount_point
+            version_added: 1.5.0
+        vars:
+          - name: ansible_hashi_vault_mount_point
+            version_added: 1.5.0
       token:
         env:
           - name: ANSIBLE_HASHI_VAULT_TOKEN


### PR DESCRIPTION

##### SUMMARY
This makes most sense; it is part of the credentials needed to
authenticate with vault, e.g. on servers with multiple independent
AppRole mountpoints.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
auth methods

##### ADDITIONAL INFORMATION
Hopefully self-explanatory, if it is not, please let me know.
