### PR TITLE
Drop support for Python 2 & 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,9 @@ See [the CI configuration](https://github.com/ansible-collections/community.hash
 
 ## Python Requirements
 
-**Python 2.6 is not supported. [Support for Python 2.7 & Python 3.5 will be dropped in `v2.0.0` of the collection.](https://github.com/ansible-collections/community.hashi_vault/issues/81)**
+**Python 2.6, 2.7, and 3.5 are not supported in version `2.0.0` or later of the collection.**
 
 Currently we support and test against Python versions:
-* 2.7
-* 3.5
 * 3.6
 * 3.7
 * 3.8

--- a/changelogs/fragments/177-drop-py2-3.5.yml
+++ b/changelogs/fragments/177-drop-py2-3.5.yml
@@ -1,3 +1,3 @@
 ---
 removed_features:
-  - community.hashi_vault collection - drop support for Python 2 and Python 3.5 (https://github.com/ansible-collections/community.hashi_vault/issues/81).
+  - drop support for Python 2 and Python 3.5 (https://github.com/ansible-collections/community.hashi_vault/issues/81).

--- a/changelogs/fragments/177-drop-py2-3.5.yml
+++ b/changelogs/fragments/177-drop-py2-3.5.yml
@@ -1,0 +1,3 @@
+---
+removed_features:
+  - community.hashi_vault collection - drop support for Python 2 and Python 3.5 (https://github.com/ansible-collections/community.hashi_vault/issues/81).

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -10,7 +10,7 @@ modules:
   # Configuration for modules/module_utils.
   # These settings do not apply to other content in the collection.
 
-  python_requires: '>=2.7'
+  python_requires: '>=3.6'
   # Python versions supported by modules/module_utils.
   # This setting is required.
   #

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,3 +1,8 @@
+# the collection supports python 3.6 and higher, however the constraints for
+# earlier python versions are still needed for Ansible < 2.12 which doesn't
+# support tests/config.yml, so that unit tests (which will be skipped) won't
+# choke on installing requirements.
+
 hvac >= 0.10.6, != 0.10.12, != 0.10.13, < 1.0.0 ; python_version == '2.7' # bugs in 0.10.12 and 0.10.13 prevent it from working in Python 2
 hvac >= 0.10.6, < 1.0.0 ; python_version == '3.5' # py3.5 support will be dropped in 1.0.0
 hvac >= 0.10.6 ; python_version >= '3.6'

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,7 +1,4 @@
-hvac >= 0.10.6, != 0.10.12, != 0.10.13, < 1.0.0 ; python_version == '2.7' # bugs in 0.10.12 and 0.10.13 prevent it from working in Python 2
-hvac >= 0.10.6, < 1.0.0 ; python_version == '3.5' # py3.5 support will be dropped in 1.0.0
 hvac >= 0.10.6 ; python_version >= '3.6'
 
 # these should be satisfied naturally by the requests versions required by hvac anyway
 urllib3 >= 1.15 ; python_version >= '3.6' # we need raise_on_status for retry support to raise the correct exceptions https://github.com/urllib3/urllib3/blob/main/CHANGES.rst#115-2016-04-06
-urllib3 >= 1.15, <2.0.0 ; python_version < '3.6' # https://urllib3.readthedocs.io/en/latest/v2-roadmap.html#optimized-for-python-3-6

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,4 +1,7 @@
+hvac >= 0.10.6, != 0.10.12, != 0.10.13, < 1.0.0 ; python_version == '2.7' # bugs in 0.10.12 and 0.10.13 prevent it from working in Python 2
+hvac >= 0.10.6, < 1.0.0 ; python_version == '3.5' # py3.5 support will be dropped in 1.0.0
 hvac >= 0.10.6 ; python_version >= '3.6'
 
 # these should be satisfied naturally by the requests versions required by hvac anyway
 urllib3 >= 1.15 ; python_version >= '3.6' # we need raise_on_status for retry support to raise the correct exceptions https://github.com/urllib3/urllib3/blob/main/CHANGES.rst#115-2016-04-06
+urllib3 >= 1.15, <2.0.0 ; python_version < '3.6' # https://urllib3.readthedocs.io/en/latest/v2-roadmap.html#optimized-for-python-3-6

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,4 +1,0 @@
----
-integration_tests_dependencies:
-  - community.crypto
-unit_tests_dependencies: []

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -11,5 +11,5 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def skip_python():
-    if sys.version_info < (2, 7):
-        pytest.skip('Skipping on Python %s. community.hashi_vault supports Python 2.7 and higher.' % sys.version)
+    if sys.version_info < (3, 6):
+        pytest.skip('Skipping on Python %s. community.hashi_vault supports Python 3.6 and higher.' % sys.version)

--- a/tests/unit/plugins/module_utils/authentication/test_hashi_vault_authenticator.py
+++ b/tests/unit/plugins/module_utils/authentication/test_hashi_vault_authenticator.py
@@ -25,11 +25,7 @@ class TestHashiVaultAuthenticator(object):
     def test_method_validate_is_called(self, authenticator, fake_auth_class):
         authenticator.validate()
 
-        # TODO: revisit in 2.0.0 when py3.5 is dropped
-        if sys.version_info < (3, 6):
-            assert fake_auth_class.validate.call_count == 1
-        else:
-            fake_auth_class.validate.assert_called_once()
+        fake_auth_class.validate.assert_called_once()
 
     def test_validate_not_implemented(self, authenticator, fake_auth_class):
         with pytest.raises(NotImplementedError):

--- a/tests/unit/plugins/module_utils/authentication/test_hashi_vault_authenticator.py
+++ b/tests/unit/plugins/module_utils/authentication/test_hashi_vault_authenticator.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import sys
 import pytest
 
 from ansible_collections.community.hashi_vault.tests.unit.compat import mock

--- a/tests/unit/plugins/module_utils/test_hashi_vault_helper.py
+++ b/tests/unit/plugins/module_utils/test_hashi_vault_helper.py
@@ -29,7 +29,6 @@ def vault_token_via_env(vault_token):
         yield
 
 
-@pytest.mark.skipif(sys.version_info < (2, 7), reason="Python 2.7 or higher is required.")
 class TestHashiVaultHelper(object):
 
     def test_get_vault_client_without_logout_explicit_token(self, hashi_vault_helper, vault_token):

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,3 +1,8 @@
+# the collection supports python 3.6 and higher, however the constraints for
+# earlier python versions are still needed for Ansible < 2.12 which doesn't
+# support tests/config.yml, so that unit tests (which will be skipped) won't
+# choke on installing requirements.
+
 hvac >= 0.10.6, != 0.10.12, != 0.10.13, < 1.0.0 ; python_version == '2.7' # bugs in 0.10.12 and 0.10.13 prevent it from working in Python 2
 hvac >= 0.10.6, < 1.0.0 ; python_version == '3.5' # py3.5 support will be dropped in 1.0.0
 hvac >= 0.10.6 ; python_version >= '3.6'

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,7 +1,4 @@
-hvac >= 0.10.6, != 0.10.12, != 0.10.13, < 1.0.0 ; python_version == '2.7' # bugs in 0.10.12 and 0.10.13 prevent it from working in Python 2
-hvac >= 0.10.6, < 1.0.0 ; python_version == '3.5' # py3.5 support will be dropped in 1.0.0
 hvac >= 0.10.6 ; python_version >= '3.6'
 
 # these should be satisfied naturally by the requests versions required by hvac anyway
 urllib3 >= 1.15 ; python_version >= '3.6' # we need raise_on_status for retry support to raise the correct exceptions https://github.com/urllib3/urllib3/blob/main/CHANGES.rst#115-2016-04-06
-urllib3 >= 1.15, <2.0.0 ; python_version < '3.6' # https://urllib3.readthedocs.io/en/latest/v2-roadmap.html#optimized-for-python-3-6

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,4 +1,7 @@
+hvac >= 0.10.6, != 0.10.12, != 0.10.13, < 1.0.0 ; python_version == '2.7' # bugs in 0.10.12 and 0.10.13 prevent it from working in Python 2
+hvac >= 0.10.6, < 1.0.0 ; python_version == '3.5' # py3.5 support will be dropped in 1.0.0
 hvac >= 0.10.6 ; python_version >= '3.6'
 
 # these should be satisfied naturally by the requests versions required by hvac anyway
 urllib3 >= 1.15 ; python_version >= '3.6' # we need raise_on_status for retry support to raise the correct exceptions https://github.com/urllib3/urllib3/blob/main/CHANGES.rst#115-2016-04-06
+urllib3 >= 1.15, <2.0.0 ; python_version < '3.6' # https://urllib3.readthedocs.io/en/latest/v2-roadmap.html#optimized-for-python-3-6


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove explicit support for Python 2.7 and 3.5 (2.6 was already unsupported).

Resolves: #81 

Not looking to explicitly break anything in those python versions, but we won't be testing against it or enforcing support in PRs. We _may_ accept PRs that look to make something that stopped working, work again in an unsupported python version, if the change is not regressive or otherwise looks reasonable. It will be a case by case basis.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
N/A

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
N/A