### PR TITLE
add missing codecov flag file association for auth_cert

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -26,6 +26,10 @@ flags:
     paths:
       - plugins/module_utils/_auth_method_aws_iam_login.py
 
+  target_auth_cert:
+    paths:
+      - plugins/module_utils/_auth_method_cert.py
+
   target_auth_jwt:
     paths:
       - plugins/module_utils/_auth_method_jwt.py


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Addendum to #159

Adds the codecov mapping for cert auth.

~This probably will not show up in coverage on the PR; I think the XML is only used from the default branch.~ it actually did work!

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- CI/coverage Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
CI/coverage

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
N/A
