### PR TITLE
deprecate Ansible 2.9 and ansible-base 2.10

### DIFF
--- a/changelogs/fragments/190-deprecate-ansible-2.9-2.10.yml
+++ b/changelogs/fragments/190-deprecate-ansible-2.9-2.10.yml
@@ -1,4 +1,4 @@
 ---
 deprecated_features:
-  - "Support for Ansible 2.9 and ansible-base 2.10 is deprecated, and will be removed in the next major release (community.hashi_vault 3.0.0) next spring.
+  - "Support for Ansible 2.9 and ansible-base 2.10 is deprecated, and will be removed in the next major release (community.hashi_vault 3.0.0) next spring
      (https://github.com/ansible-community/community-topics/issues/50, https://github.com/ansible-collections/community.hashi_vault/issues/189)."

--- a/changelogs/fragments/190-deprecate-ansible-2.9-2.10.yml
+++ b/changelogs/fragments/190-deprecate-ansible-2.9-2.10.yml
@@ -1,0 +1,4 @@
+---
+deprecated_features:
+  - "Support for Ansible 2.9 and ansible-base 2.10 is deprecated, and will be removed in the next major release (community.hashi_vault 3.0.0) next spring.
+     (https://github.com/ansible-community/community-topics/issues/50, https://github.com/ansible-collections/community.hashi_vault/pull/190)."

--- a/changelogs/fragments/190-deprecate-ansible-2.9-2.10.yml
+++ b/changelogs/fragments/190-deprecate-ansible-2.9-2.10.yml
@@ -1,4 +1,4 @@
 ---
 deprecated_features:
   - "Support for Ansible 2.9 and ansible-base 2.10 is deprecated, and will be removed in the next major release (community.hashi_vault 3.0.0) next spring.
-     (https://github.com/ansible-community/community-topics/issues/50, https://github.com/ansible-collections/community.hashi_vault/pull/190)."
+     (https://github.com/ansible-community/community-topics/issues/50, https://github.com/ansible-collections/community.hashi_vault/issues/189)."


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR announces the deprecation of Ansible 2.9 and ansible-base 2.10 support.

Related:
- #189
- https://github.com/ansible-community/community-topics/issues/50

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

