### PR TITLE
Add tests for `ldap` auth method

### DIFF
--- a/tests/integration/targets/auth_ldap/aliases
+++ b/tests/integration/targets/auth_ldap/aliases
@@ -1,0 +1,2 @@
+vault/auth/ldap
+context/target

--- a/tests/integration/targets/auth_ldap/defaults/main.yml
+++ b/tests/integration/targets/auth_ldap/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+ansible_hashi_vault_url: '{{ vault_mmock_server_http }}'
+ansible_hashi_vault_auth_method: ldap
+
+auth_paths:
+  - ldap
+  - ldap-alt
+
+ldap_username: ldapuser
+ldap_password: ldappass

--- a/tests/integration/targets/auth_ldap/meta/main.yml
+++ b/tests/integration/targets/auth_ldap/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - setup_vault_test_plugins
+  - setup_vault_configure

--- a/tests/integration/targets/auth_ldap/tasks/ldap_test_controller.yml
+++ b/tests/integration/targets/auth_ldap/tasks/ldap_test_controller.yml
@@ -1,0 +1,32 @@
+- name: "Test block"
+  vars:
+    is_default_path: "{{ this_path == default_path }}"
+    kwargs_mount: "{{ {} if is_default_path else {'mount_point': this_path} }}"
+    kwargs_common:
+      password: '{{ ldap_password }}'
+    kwargs: "{{ kwargs_common | combine(kwargs_mount) }}"
+  block:
+    # the purpose of this test is to catch when the plugin accepts mount_point but does not pass it into hvac
+    # we set the policy of the default mount to deny access to this secret and so we expect failure when the mount
+    # is default, and success when the mount is alternate
+    - name: Check auth mount differing result
+      set_fact:
+        response: "{{ lookup('vault_test_auth', '', username=ldap_username, **kwargs) }}"
+
+    - assert:
+        fail_msg: "A token from mount path '{{ this_path }}' had the wrong policy: {{ response.login.auth.policies }}"
+        that:
+          - ('ldap-sample-policy' in response.login.auth.policies) | bool == is_default_path
+          - ('ldap-sample-policy' not in response.login.auth.policies) | bool != is_default_path
+          - ('ldap-alt-sample-policy' in response.login.auth.policies) | bool != is_default_path
+          - ('ldap-alt-sample-policy' not in response.login.auth.policies) | bool == is_default_path
+
+    - name: Failure expected when something goes wrong (simulated)
+      set_fact:
+        response: "{{ lookup('vault_test_auth', '', username='fail-me-username', want_exception=true, **kwargs) }}"
+
+    - assert:
+        fail_msg: "An invalid request somehow did not cause a failure."
+        that:
+          - response is failed
+          - "response.msg is search('ldap operation failed: failed to bind as user')"

--- a/tests/integration/targets/auth_ldap/tasks/ldap_test_target.yml
+++ b/tests/integration/targets/auth_ldap/tasks/ldap_test_target.yml
@@ -1,0 +1,37 @@
+- name: "Test block"
+  vars:
+    is_default_path: "{{ this_path == default_path }}"
+  module_defaults:
+    vault_test_auth:
+      url: '{{ ansible_hashi_vault_url }}'
+      auth_method: '{{ ansible_hashi_vault_auth_method }}'
+      mount_point: '{{ omit if is_default_path else this_path }}'
+      username: '{{ ldap_username }}'
+      password: '{{ ldap_password }}'
+  block:
+    # the purpose of this test is to catch when the plugin accepts mount_point but does not pass it into hvac
+    # we set the policy of the default mount to deny access to this secret and so we expect failure when the mount
+    # is default, and success when the mount is alternate
+    - name: Check auth mount differing result
+      register: response
+      vault_test_auth:
+
+    - assert:
+        fail_msg: "A token from mount path '{{ this_path }}' had the wrong policy: {{ response.login.auth.policies }}"
+        that:
+          - ('ldap-sample-policy' in response.login.auth.policies) | bool == is_default_path
+          - ('ldap-sample-policy' not in response.login.auth.policies) | bool != is_default_path
+          - ('ldap-alt-sample-policy' in response.login.auth.policies) | bool != is_default_path
+          - ('ldap-alt-sample-policy' not in response.login.auth.policies) | bool == is_default_path
+
+    - name: Failure expected when something goes wrong (simulated)
+      register: response
+      vault_test_auth:
+        username: fail-me-username
+        want_exception: yes
+
+    - assert:
+        fail_msg: "An invalid request somehow did not cause a failure."
+        that:
+          - response.inner is failed
+          - "response.msg is search('ldap operation failed: failed to bind as user')"

--- a/tests/integration/targets/auth_ldap/tasks/main.yml
+++ b/tests/integration/targets/auth_ldap/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+# task vars are not templated when used as vars, so we'll need to set_fact this evaluate the template
+# see: https://github.com/ansible/ansible/issues/73268
+- name: Persist defaults
+  set_fact:
+    '{{ item.key }}': "{{ lookup('vars', item.key) }}"
+  loop: "{{ lookup('file', role_path ~ '/defaults/main.yml') | from_yaml | dict2items }}"
+  loop_control:
+    label: '{{ item.key }}'
+
+# there's no setup for this auth method because its API is mocked
+
+- name: Run ldap tests
+  loop: '{{ auth_paths | product(["target", "controller"]) | list }}'
+  include_tasks:
+    file: ldap_test_{{ item[1] }}.yml
+    apply:
+      vars:
+        default_path: ldap
+        this_path: '{{ item[0] }}'
+      module_defaults:
+        assert:
+          quiet: yes

--- a/tests/integration/targets/setup_localenv_docker/templates/mmock/ldap_login_alt_mount.yml.j2
+++ b/tests/integration/targets/setup_localenv_docker/templates/mmock/ldap_login_alt_mount.yml.j2
@@ -1,0 +1,41 @@
+#jinja2:variable_start_string:'[%', variable_end_string:'%]'
+---
+request:
+  method: POST|PUT
+  path: "/v1/auth/ldap-alt/login/:user"
+control:
+  priority: 10
+response:
+  statusCode: 200
+  headers:
+    Content-Type:
+      - application/json
+  body: >-
+    {
+        "request_id": "{{fake.UUID}}",
+        "lease_id": "",
+        "lease_duration": 0,
+        "renewable": false,
+        "data": {},
+        "warnings": null,
+        "auth": {
+            "client_token": "s.{{fake.CharactersN(24)}}",
+            "accessor": "{{fake.CharactersN(24)}}",
+            "policies": [
+                "default",
+                "ldap-sample-policy"
+            ],
+            "token_policies": [
+                "default",
+                "ldap-sample-policy"
+            ],
+            "identity_policies": null,
+            "metadata": {
+                "username": "{{request.path.user}}"
+            },
+            "orphan": true,
+            "entity_id": "{{fake.UUID}}",
+            "lease_duration": 3600,
+            "renewable": true
+        }
+    }

--- a/tests/integration/targets/setup_localenv_docker/templates/mmock/ldap_login_alt_mount.yml.j2
+++ b/tests/integration/targets/setup_localenv_docker/templates/mmock/ldap_login_alt_mount.yml.j2
@@ -23,11 +23,11 @@ response:
             "accessor": "{{fake.CharactersN(24)}}",
             "policies": [
                 "default",
-                "ldap-sample-policy"
+                "ldap-alt-sample-policy"
             ],
             "token_policies": [
                 "default",
-                "ldap-sample-policy"
+                "ldap-alt-sample-policy"
             ],
             "identity_policies": null,
             "metadata": {

--- a/tests/integration/targets/setup_localenv_docker/templates/mmock/ldap_login_bad_request.yml.j2
+++ b/tests/integration/targets/setup_localenv_docker/templates/mmock/ldap_login_bad_request.yml.j2
@@ -1,0 +1,18 @@
+#jinja2:variable_start_string:'[%', variable_end_string:'%]'
+---
+request:
+  method: POST|PUT
+  path: "/v1/auth/ldap*/login/fail-me-username"
+control:
+  priority: 11
+response:
+  statusCode: 400
+  headers:
+    Content-Type:
+      - application/json
+  body: >-
+    {
+        "errors": [
+            "ldap operation failed: failed to bind as user"
+        ]
+    }

--- a/tests/integration/targets/setup_localenv_docker/templates/mmock/ldap_login_default_mount.yml.j2
+++ b/tests/integration/targets/setup_localenv_docker/templates/mmock/ldap_login_default_mount.yml.j2
@@ -1,0 +1,41 @@
+#jinja2:variable_start_string:'[%', variable_end_string:'%]'
+---
+request:
+  method: POST|PUT
+  path: "/v1/auth/ldap/login/:user"
+control:
+  priority: 10
+response:
+  statusCode: 200
+  headers:
+    Content-Type:
+      - application/json
+  body: >-
+    {
+        "request_id": "{{fake.UUID}}",
+        "lease_id": "",
+        "lease_duration": 0,
+        "renewable": false,
+        "data": {},
+        "warnings": null,
+        "auth": {
+            "client_token": "s.{{fake.CharactersN(24)}}",
+            "accessor": "{{fake.CharactersN(24)}}",
+            "policies": [
+                "default",
+                "ldap-sample-policy"
+            ],
+            "token_policies": [
+                "default",
+                "ldap-sample-policy"
+            ],
+            "identity_policies": null,
+            "metadata": {
+                "username": "{{request.path.user}}"
+            },
+            "orphan": true,
+            "entity_id": "{{fake.UUID}}",
+            "lease_duration": 3600,
+            "renewable": true
+        }
+    }

--- a/tests/unit/plugins/module_utils/authentication/fixtures/ldap_login_response.json
+++ b/tests/unit/plugins/module_utils/authentication/fixtures/ldap_login_response.json
@@ -1,0 +1,28 @@
+{
+    "request_id": "30fd9f34-83af-4921-be0c-b93e41dc3959",
+    "lease_id": "",
+    "lease_duration": 0,
+    "renewable": false,
+    "data": {},
+    "warnings": null,
+    "auth": {
+        "client_token": "s.fjXSOvsGY3Q95XGyJKnDw7OC",
+        "accessor": "VnnNWBasAnVn1YO4cVL9jJei",
+        "policies": [
+            "default",
+            "test-policy"
+        ],
+        "token_policies": [
+            "default",
+            "test-policy"
+        ],
+        "identity_policies": null,
+        "metadata": {
+            "username": "ldapuser"
+        },
+        "orphan": true,
+        "entity_id": "08e5b262-7dc2-4edd-8fc7-77882ca7cc1b",
+        "lease_duration": 3600,
+        "renewable": true
+    }
+}

--- a/tests/unit/plugins/module_utils/authentication/test_auth_ldap.py
+++ b/tests/unit/plugins/module_utils/authentication/test_auth_ldap.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 Brian Scholer (@briantist)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.community.hashi_vault.tests.unit.compat import mock
+
+from ansible_collections.community.hashi_vault.plugins.module_utils._auth_method_ldap import (
+    HashiVaultAuthMethodLdap,
+)
+
+from ansible_collections.community.hashi_vault.plugins.module_utils._hashi_vault_common import (
+    HashiVaultAuthMethodBase,
+    HashiVaultValueError,
+)
+
+
+@pytest.fixture
+def option_dict():
+    return {
+        'auth_method': 'ldap',
+        'username': None,
+        'password': None,
+        'mount_point': None,
+    }
+
+
+@pytest.fixture
+def ldap_username():
+    return 'ldapuser'
+
+
+@pytest.fixture
+def ldap_password():
+    return 's3cret'
+
+
+@pytest.fixture
+def auth_ldap(adapter, warner):
+    return HashiVaultAuthMethodLdap(adapter, warner)
+
+
+@pytest.fixture
+def ldap_login_response(fixture_loader):
+    return fixture_loader('ldap_login_response.json')
+
+
+class TestAuthLdap(object):
+
+    def test_auth_ldap_is_auth_method_base(self, auth_ldap):
+        assert isinstance(auth_ldap, HashiVaultAuthMethodLdap)
+        assert issubclass(HashiVaultAuthMethodLdap, HashiVaultAuthMethodBase)
+
+    @pytest.mark.parametrize('mount_point', [None, 'other'], ids=lambda x: 'mount_point=%s' % x)
+    def test_auth_ldap_validate(self, auth_ldap, adapter, ldap_username, ldap_password, mount_point):
+        adapter.set_options(username=ldap_username, password=ldap_password, mount_point=mount_point)
+
+        auth_ldap.validate()
+
+    @pytest.mark.parametrize('opt_patch', [
+        {'username': 'user-only'},
+        {'password': 'password-only'},
+    ])
+    def test_auth_ldap_validate_xfailures(self, auth_ldap, adapter, opt_patch):
+        adapter.set_options(**opt_patch)
+
+        with pytest.raises(HashiVaultValueError, match=r'Authentication method ldap requires options .*? to be set, but these are missing:'):
+            auth_ldap.validate()
+
+    @pytest.mark.parametrize('use_token', [True, False], ids=lambda x: 'use_token=%s' % x)
+    @pytest.mark.parametrize('mount_point', [None, 'other'], ids=lambda x: 'mount_point=%s' % x)
+    def test_auth_ldap_authenticate(
+        self, auth_ldap, client, adapter, ldap_password, ldap_username, mount_point, use_token, ldap_login_response
+    ):
+        adapter.set_option('username', ldap_username)
+        adapter.set_option('password', ldap_password)
+        adapter.set_option('mount_point', mount_point)
+
+        expected_login_params = {
+            'username': ldap_username,
+            'password': ldap_password,
+        }
+        if mount_point:
+            expected_login_params['mount_point'] = mount_point
+
+        auth_ldap.validate()
+
+        def _set_client_token(*args, **kwargs):
+            if kwargs['use_token']:
+                client.token = ldap_login_response['auth']['client_token']
+            return ldap_login_response
+
+        with mock.patch.object(client.auth.ldap, 'login', side_effect=_set_client_token) as ldap_login:
+            response = auth_ldap.authenticate(client, use_token=use_token)
+            ldap_login.assert_called_once_with(use_token=use_token, **expected_login_params)
+
+        assert response['auth']['client_token'] == ldap_login_response['auth']['client_token']
+        assert (client.token == ldap_login_response['auth']['client_token']) is use_token


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #117 

Adds unit and integration tests for the `ldap` auth method.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
tests/

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
There have never been tests for `ldap` auth method; with the addition of MMock in #193 , we can test this in a similar way, mocking the result from Vault without having to set up an LDAP server.
<!--- Paste verbatim command output below, e.g. before and after your change -->
