### PR TITLE
docs build- fix repo name on scheduled runs

### DIFF
--- a/.github/workflows/_shared-docs-build-push.yml
+++ b/.github/workflows/_shared-docs-build-push.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       collection-name:
-        description: The collection name in the form namespace/collection.
+        description: The collection name in the form namespace.collection.
         required: false
         type: string
         default: ${{ github.event.repository.name }}
@@ -56,6 +56,12 @@ jobs:
           script: |
             const inputs = ${{ toJSON(inputs) }}
             var colpath = inputs['collection-path']
+            var colname = inputs['collection-name']
+
+            if (colname == '') {
+                colname = process.env.GITHUB_REPOSITORY.split('/')[1]
+            }
+
             if (colpath == '') {
                 colpath = inputs['collection-name'].replace('.', '/')
             }
@@ -64,6 +70,7 @@ jobs:
 
             const checkoutPath = `ansible_collections/${colpath}`
 
+            core.setOutput('col-name', colname)
             core.setOutput('col-path', colpath)
             core.setOutput('checkout-path', checkoutPath)
 
@@ -95,7 +102,7 @@ jobs:
         id: init
         uses: ansible-collections/community.hashi_vault/.github/actions/docs/ansible-docs-build-init@main
         with:
-          collections: ${{ inputs.collection-name }}
+          collections: ${{ steps.vars.outputs.col-name }}
           dest-dir: ${{ steps.vars.outputs.init-dir }}
           skip-init: ${{ steps.vars.outputs.skip-init }}
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Related: #202 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

The default value for the collection name didn't work on scheduled runs because it's not available. Handling via the script plugin.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs build

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
