### PR TITLE
docs build - try to fix PR closed with no change

### DIFF
--- a/.github/actions/docs/ansible-docs-build-html/action.yml
+++ b/.github/actions/docs/ansible-docs-build-html/action.yml
@@ -34,6 +34,9 @@ outputs:
   artifact-url:
     description: The URL to the artifact.
     value: ${{ steps.outs.outputs.artifact-url }}
+  artifact-name:
+    description: The name of the uploaded artifact.
+    value: ${{ inputs.artifact-name }}
   build-html:
     description: The end location of the built HTML files.
     value: ${{ steps.build.outputs.build-html }}

--- a/.github/workflows/_shared-docs-build-push.yml
+++ b/.github/workflows/_shared-docs-build-push.yml
@@ -63,7 +63,7 @@ jobs:
             }
 
             if (colpath == '') {
-                colpath = inputs['collection-name'].replace('.', '/')
+                colpath = colname.replace('.', '/')
             }
 
             core.exportVariable('ANSIBLE_COLLECTIONS_PATHS', process.env.GITHUB_WORKSPACE)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,6 @@ env:
 
 jobs:
   build-docs:
-    if: github.event.action != 'closed'
     permissions:
       contents: read
     name: Build Ansible Docs
@@ -42,9 +41,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     needs: [build-docs, publish-docs]
-    if: >-
-      always()
-      && (needs.build-docs.result == 'success' || github.event.action == 'closed')
     name: PR comments
     steps:
       - name: PR comment
@@ -55,7 +51,7 @@ jobs:
         with:
           body-includes: '##Docs Build'
           reactions: heart
-          action: ${{ (needs.build-docs.result == 'success' && needs.build-docs.outputs.changed != 'true') && 'remove' || '' }}
+          action: ${{ needs.build-docs.outputs.changed != 'true' && 'remove' || '' }}
           on-closed-body: |
             ##Docs Build 📝
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,22 @@ jobs:
       init-dest-dir: docs/preview
       render-file-line: '> * `$<status>` [$<path_tail>](https://community-hashi-vault-pr${{ github.event.number }}.surge.sh/$<path_tail>)'
 
+  debug:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    needs: build-docs
+    steps:
+      - name: DEBUG
+        shell: bash
+        run: |
+          echo "changed: ${{ needs.build-docs.outputs.changed }}"
+          echo "ne true: ${{ needs.build-docs.outputs.changed != 'true' }}"
+          echo "!changed: ${{ !needs.build-docs.outputs.changed }}"
+          echo <<EOF
+          ${{ toJSON(needs.build-docs.outputs) }}
+          EOF
+
   publish-docs:
     permissions:
       contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
     with:
       artifact-name: ${{ needs.build-docs.outputs.artifact-name }}
       surge-site-name: community-hashi-vault-pr${{ github.event.number }}.surge.sh
-      action: ${{ (github.event.action == 'closed' || !needs.build-docs.outputs.changed) && 'teardown' || 'publish' }}
+      action: ${{ (github.event.action == 'closed' || needs.build-docs.outputs.changed != 'true') && 'teardown' || 'publish' }}
     secrets:
       SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,9 +24,6 @@ jobs:
     permissions:
       contents: read
     needs: build-docs
-    if: >-
-      always()
-      && (needs.build-docs.result == 'success' || github.event.action == 'closed')
     name: Publish Ansible Docs
     uses: ansible-collections/community.hashi_vault/.github/workflows/_shared-docs-build-publish-surge.yml@main
     with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,22 +20,6 @@ jobs:
       init-dest-dir: docs/preview
       render-file-line: '> * `$<status>` [$<path_tail>](https://community-hashi-vault-pr${{ github.event.number }}.surge.sh/$<path_tail>)'
 
-  debug:
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    needs: build-docs
-    steps:
-      - name: DEBUG
-        shell: bash
-        run: |
-          echo "changed: ${{ needs.build-docs.outputs.changed }}"
-          echo "ne true: ${{ needs.build-docs.outputs.changed != 'true' }}"
-          echo "!changed: ${{ !needs.build-docs.outputs.changed }}"
-          echo <<EOF
-          ${{ toJSON(needs.build-docs.outputs) }}
-          EOF
-
   publish-docs:
     permissions:
       contents: read


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The new docs build was skipping the build step in a PR when it was closed. Because of this, it did not know whether the original PR had made docs changes or not, resulting in it always posting a comment that the "changes" had been merged.

This PR changes the behavior so that the build always runs, that way we can know whether there were changes. That makes it a bit slower, but that's hardly a concern. On a positive note, it simplifies the conditionals needed for running dependent jobs.

Also threw in another fix that should've been in #203 .

And added artifact name as an output from the build-html action'

---

Results from #204 look good for fixing change detection on closed/merged PRs and showing the appropriate message.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs build

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
