### PR TITLE
add k8s auth  to lookup hashi_vault - operator

### DIFF
--- a/plugins/doc_fragments/auth.py
+++ b/plugins/doc_fragments/auth.py
@@ -27,6 +27,7 @@ class ModuleDocFragment(object):
           - jwt
           - cert
           - none
+          - k8s
         default: token
         type: str
       mount_point:

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -181,6 +181,18 @@ DOCUMENTATION = """
         - section: hashi_vault_collection
           key: token_validate
           version_added: 1.4.0
+    role:
+      ini:
+        - section: lookup_hashi_vault
+          key: role
+          deprecated:
+            why: collection-wide config section
+            version: 3.0.0
+            collection_name: community.hashi_vault
+            alternatives: use section [hashi_vault_collection]
+        - section: hashi_vault_collection
+          key: role
+          version_added: 2.3.0
     role_id:
       ini:
         - section: lookup_hashi_vault

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -181,18 +181,6 @@ DOCUMENTATION = """
         - section: hashi_vault_collection
           key: token_validate
           version_added: 1.4.0
-    role:
-      ini:
-        - section: lookup_hashi_vault
-          key: role
-          deprecated:
-            why: collection-wide config section
-            version: 3.0.0
-            collection_name: community.hashi_vault
-            alternatives: use section [hashi_vault_collection]
-        - section: hashi_vault_collection
-          key: role
-          version_added: 2.3.0
     role_id:
       ini:
         - section: lookup_hashi_vault

--- a/plugins/module_utils/_auth_method_k8s.py
+++ b/plugins/module_utils/_auth_method_k8s.py
@@ -20,13 +20,13 @@ class HashiVaultAuthMethodK8S(HashiVaultAuthMethodBase):
     '''HashiVault option group class for auth: k8s'''
 
     NAME = 'k8s'
-    OPTIONS = ['jwt', 'role', 'mount_point']
+    OPTIONS = ['jwt', 'role_id', 'mount_point']
 
     def __init__(self, option_adapter, warning_callback):
         super(HashiVaultAuthMethodK8S, self).__init__(option_adapter, warning_callback)
 
     def validate(self):
-        self.validate_by_required_fields('role')
+        self.validate_by_required_fields('role_id')
 
     def authenticate(self, client, use_token=True):
         params = self._options.get_filled_options(*self.OPTIONS)
@@ -38,6 +38,8 @@ class HashiVaultAuthMethodK8S(HashiVaultAuthMethodBase):
                 params['jwt'] = jwt
             except:
                 raise NotImplementedError("Can't read jwt in /var/run/secrets/kubernetes.io/serviceaccount/token")
+        params['role'] = params.pop('role_id')
+        
         try:
             response = client.auth_kubernetes(**params)
         except (NotImplementedError, AttributeError):

--- a/plugins/module_utils/_auth_method_k8s.py
+++ b/plugins/module_utils/_auth_method_k8s.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 FERREIRA Christophe (@chris93111)
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+'''Python versions supported: all controller-side versions, all remote-side versions except 2.6'''
+
+# FOR INTERNAL COLLECTION USE ONLY
+# The interfaces in this file are meant for use within the community.hashi_vault collection
+# and may not remain stable to outside uses. Changes may be made in ANY release, even a bugfix release.
+# See also: https://github.com/ansible/community/issues/539#issuecomment-780839686
+# Please open an issue if you have questions about this.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible_collections.community.hashi_vault.plugins.module_utils._hashi_vault_common import HashiVaultAuthMethodBase
+
+
+class HashiVaultAuthMethodK8S(HashiVaultAuthMethodBase):
+    '''HashiVault option group class for auth: k8s'''
+
+    NAME = 'k8s'
+    OPTIONS = ['jwt', 'role', 'mount_point']
+
+    def __init__(self, option_adapter, warning_callback):
+        super(HashiVaultAuthMethodK8S, self).__init__(option_adapter, warning_callback)
+
+    def validate(self):
+        self.validate_by_required_fields('role')
+
+    def authenticate(self, client, use_token=True):
+        params = self._options.get_filled_options(*self.OPTIONS)
+        if not params['jwt']:
+            # Mode in cluster fetch jwt in pods
+            try:
+                f = open('/var/run/secrets/kubernetes.io/serviceaccount/token')
+                jwt = f.read()
+                params['jwt'] = jwt
+            except:
+                raise NotImplementedError("Can't read jwt in /var/run/secrets/kubernetes.io/serviceaccount/token")
+        try:
+            response = client.auth_kubernetes(**params)
+        except (NotImplementedError, AttributeError):
+            raise NotImplementedError("K8S authentication requires HVAC version 0.8.0 or higher.")
+
+        return response

--- a/plugins/module_utils/_auth_method_k8s.py
+++ b/plugins/module_utils/_auth_method_k8s.py
@@ -30,7 +30,7 @@ class HashiVaultAuthMethodK8S(HashiVaultAuthMethodBase):
 
     def authenticate(self, client, use_token=True):
         params = self._options.get_filled_options(*self.OPTIONS)
-        if not params['jwt']:
+        if not params.get('jwt'):
             # Mode in cluster fetch jwt in pods
             try:
                 f = open('/var/run/secrets/kubernetes.io/serviceaccount/token')

--- a/plugins/module_utils/_authenticator.py
+++ b/plugins/module_utils/_authenticator.py
@@ -57,7 +57,6 @@ class HashiVaultAuthenticator():
         aws_iam_server_id=dict(type='str'),
         cert_auth_private_key=dict(type='path', no_log=False),
         cert_auth_public_key=dict(type='path'),
-        role=dict(type='str'),
     )
 
     def __init__(self, option_adapter, warning_callback):

--- a/plugins/module_utils/_authenticator.py
+++ b/plugins/module_utils/_authenticator.py
@@ -22,6 +22,7 @@ from ansible_collections.community.hashi_vault.plugins.module_utils._auth_method
 from ansible_collections.community.hashi_vault.plugins.module_utils._auth_method_none import HashiVaultAuthMethodNone
 from ansible_collections.community.hashi_vault.plugins.module_utils._auth_method_token import HashiVaultAuthMethodToken
 from ansible_collections.community.hashi_vault.plugins.module_utils._auth_method_userpass import HashiVaultAuthMethodUserpass
+from ansible_collections.community.hashi_vault.plugins.module_utils._auth_method_k8s import HashiVaultAuthMethodK8S
 
 
 class HashiVaultAuthenticator():
@@ -36,6 +37,7 @@ class HashiVaultAuthenticator():
             'jwt',
             'cert',
             'none',
+            'k8s',
         ]),
         mount_point=dict(type='str'),
         token=dict(type='str', no_log=True, default=None),
@@ -55,6 +57,7 @@ class HashiVaultAuthenticator():
         aws_iam_server_id=dict(type='str'),
         cert_auth_private_key=dict(type='path', no_log=False),
         cert_auth_public_key=dict(type='path'),
+        role=dict(type='str'),
     )
 
     def __init__(self, option_adapter, warning_callback):
@@ -66,6 +69,7 @@ class HashiVaultAuthenticator():
             'aws_iam': HashiVaultAuthMethodAwsIam(option_adapter, warning_callback),
             'cert': HashiVaultAuthMethodCert(option_adapter, warning_callback),
             'jwt': HashiVaultAuthMethodJwt(option_adapter, warning_callback),
+            'k8s': HashiVaultAuthMethodK8S(option_adapter, warning_callback),
             'ldap': HashiVaultAuthMethodLdap(option_adapter, warning_callback),
             'none': HashiVaultAuthMethodNone(option_adapter, warning_callback),
             'token': HashiVaultAuthMethodToken(option_adapter, warning_callback),


### PR DESCRIPTION
##### SUMMARY
Add authentification k8s in lookup, for ansible operator (operator-sdk) use service account jwt token in login

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lookup hashi_vault

```
- name: vault test jwt k8s
  hosts: localhost
  connection: localhost
  tasks:
    - name: try fetch secret with jwt SA
      debug:
        msg: "{{ lookup('community.hashi_vault.hashi_vault', 'secret=ansible/data/tower/credential/user1 auth_method=k8s mount_point=kubernetes-cluster1 role_id=awx url=https://vault:443')}}"

```
