### PR TITLE
codecov - try different path format

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,7 @@
 ---
 ignore:
-  - "**/tests/unit/compat/*"
-  - "**/tests/unit/**/conftest.py"
+  - tests/unit/compat/*
+  - tests/unit/**/conftest.py
 
 fixes:
   - "ansible_collections/community/hashi_vault/::"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I think I've been using the wrong paths for the ignore section, I was trying to start them with `**/` but since the paths started in the root, I think the path fixing was trimming off the beginnings (like it was supposed to), and so the `/` part was causing them not to match... trying to see if this works.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- CI Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
n/a

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
n/a