### PR TITLE
use wrapping doc fragment for `vault_token_create`

### DIFF
--- a/plugins/doc_fragments/token_create.py
+++ b/plugins/doc_fragments/token_create.py
@@ -92,7 +92,4 @@ options:
       - Only works in combination with I(role_name) option and used entity alias must be listed in C(allowed_entity_aliases).
       - If this has been specified, the entity will not be inherited from the parent.
     type: str
-  wrap_ttl:
-    description: Specifies response wrapping token creation with duration. For example C(15s), C(20m), C(25h).
-    type: str
 '''

--- a/plugins/lookup/vault_token_create.py
+++ b/plugins/lookup/vault_token_create.py
@@ -35,6 +35,8 @@ DOCUMENTATION = """
     - community.hashi_vault.auth
     - community.hashi_vault.auth.plugins
     - community.hashi_vault.token_create
+    - community.hashi_vault.wrapping
+    - community.hashi_vault.wrapping.plugins
   options:
     _terms:
       description: This is unused and any terms supplied will be ignored.

--- a/plugins/modules/vault_token_create.py
+++ b/plugins/modules/vault_token_create.py
@@ -29,6 +29,7 @@ DOCUMENTATION = """
     - community.hashi_vault.connection
     - community.hashi_vault.auth
     - community.hashi_vault.token_create
+    - community.hashi_vault.wrapping
   notes:
     - Token creation is a write operation (creating a token persisted to storage), so this module always reports C(changed=True).
     - For the purposes of Ansible playbooks however,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Resolves #227
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

This doesn't really change much for the end user, it just makes an existing option use a doc fragment.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vault_token_create 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
N/A