### PR TITLE
Docs/strict and lenient

### DIFF
--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -18,6 +18,8 @@ jobs:
     with:
       ansible-ref: devel
       init-dest-dir: docs/preview
+      init-lenient: false
+      init-fail-on-error: true
 
   publish-docs:
     # for now we won't run this on forks

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -10,23 +10,33 @@ on:
     - cron: '0 13 * * *'
 
 jobs:
+  validate-docs:
+    permissions:
+      contents: read
+    name: Validate Ansible Docs
+    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-push.yml@main
+    with:
+      init-lenient: false
+      init-fail-on-error: true
+      artifact-name: _unused
+
   build-docs:
     permissions:
       contents: read
     name: Build Ansible Docs
     uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-push.yml@main
     with:
-      ansible-ref: devel
       init-dest-dir: docs/preview
-      init-lenient: false
-      init-fail-on-error: true
+      # Although we want this to be the most strict, we can't currently achieve this
+      # with the committed init-dest-dir, hence the validate-docs job, which will
+      # prevent publish from running in the case of failures.
 
   publish-docs:
     # for now we won't run this on forks
     if: github.repository == 'ansible-collections/community.hashi_vault'
     permissions:
       contents: read
-    needs: build-docs
+    needs: [validate-docs, build-docs]
     name: Publish Ansible Docs
     uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-publish-surge.yml@main
     with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
   validate-docs:
     permissions:
       contents: read
-    name: Build Ansible Docs
+    name: Validate Ansible Docs
     uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-push.yml@main
     with:
       init-dest-dir: docs/preview

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,22 @@ env:
   SURGE_MAIN_SITE: community-hashi-vault-main.surge.sh
 
 jobs:
+  # this job builds with the most strict options to ensure full compliance
+  validate-docs:
+    permissions:
+      contents: read
+    name: Build Ansible Docs
+    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-push.yml@main
+    with:
+      init-dest-dir: docs/preview
+      init-lenient: false
+      init-fail-on-error: true
+      artifact-name: _unused
+
+  # this job builds for the PR comparison and publish, so use the most lenient options
+  # to give the best possibility of producing a publishable build; the strict buil will
+  # still result in a failure for the PR as a whole, but for review a partial docsite is
+  # better than none.
   build-docs:
     permissions:
       contents: read
@@ -19,6 +35,8 @@ jobs:
     with:
       ansible-ref: devel
       init-dest-dir: docs/preview
+      init-lenient: true
+      init-fail-on-error: false
       render-file-line: '> * `$<status>` [$<path_tail>](https://community-hashi-vault-pr${{ github.event.number }}.surge.sh/$<path_tail>)'
 
   publish-docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,31 +12,58 @@ env:
 
 jobs:
   # this job builds with the most strict options to ensure full compliance
+  # does not use the collection's committed sphinx-init output
+  # we can't currently use the "push" shared workflow, because we have no way
+  # to override its ref.
   validate-docs:
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     name: Validate Ansible Docs
-    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-push.yml@main
-    with:
-      init-dest-dir: docs/preview
-      init-lenient: false
-      init-fail-on-error: true
-      artifact-name: _unused
+    env:
+      ANSIBLE_COLLECTIONS_PATHS: ${{ github.workspace }}
+    if: github.event.action != 'closed'
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+
+      - name: Install Ansible
+        run: pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: refs/pull/${{ github.event.number }}/merge
+          path: ansible_collections/community/hashi_vault
+
+      - name: Initialize the build environment
+        id: init
+        uses: ansible-community/github-docs-build/actions/ansible-docs-build-init@main
+        with:
+          collections: community.hashi_vault
+          lenient: false
+          fail-on-error: true
+
+      - name: Build
+        id: build
+        uses: ansible-community/github-docs-build/actions/ansible-docs-build-html@main
+        with:
+          artifact-upload: false
 
   # this job builds for the PR comparison and publish, so use the most lenient options
-  # to give the best possibility of producing a publishable build; the strict buil will
+  # to give the best possibility of producing a publishable build; the strict build will
   # still result in a failure for the PR as a whole, but for review a partial docsite is
   # better than none.
+  # This uses the committed sphinx-init output which already has the lenient options.
   build-docs:
     permissions:
       contents: read
     name: Build Ansible Docs
     uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-pr.yml@main
     with:
-      ansible-ref: devel
       init-dest-dir: docs/preview
-      init-lenient: true
-      init-fail-on-error: false
       render-file-line: '> * `$<status>` [$<path_tail>](https://community-hashi-vault-pr${{ github.event.number }}.surge.sh/$<path_tail>)'
 
   publish-docs:

--- a/docs/preview/build.sh
+++ b/docs/preview/build.sh
@@ -14,6 +14,6 @@ antsibull-docs collection \
 rsync -avc --delete-after temp-rst/collections/ rst/collections/
 
 # Build Sphinx site
-sphinx-build -M html rst build -c . -W --keep-going
+sphinx-build -M html rst build -c .
 
 popd

--- a/docs/preview/requirements.txt
+++ b/docs/preview/requirements.txt
@@ -1,4 +1,4 @@
-antsibull
+antsibull-docs
 ansible-pygments
 sphinx
 sphinx-ansible-theme


### PR DESCRIPTION
##### SUMMARY
Builds on the changes in https://github.com/ansible-community/github-docs-build/pull/27 .

* Set the push build to the strictest set of option
* On PR, set the PR build to the most lenient set of options; this gives us the best possibility of a publishable build, because a partial build of the docsite is more useful than none at all
* On PR, add an additional docs build (no comparison to base) with the most strict settings; this serves as the quality/validator for the PR, so even if the lenient build for the PR publish passes, this one will catch other errors and "fail" the PR

<!--- Describe the change below, including rationale and design decisions -->
As with all `pull_request_target` workflow changes, the tests run in this PR do not test the changes to the workflow.

Test PR is needed against this branch to test functionality.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs-build

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<!--- Paste verbatim command output below, e.g. before and after your change -->
