### PR TITLE
bump deps, add stable-2.13

### DIFF
--- a/.github/workflows/ansible-builder.yml
+++ b/.github/workflows/ansible-builder.yml
@@ -22,12 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ansible_collections/${{ env.NAMESPACE }}/${{ env.COLLECTION_NAME }}
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.9
 

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -41,6 +41,7 @@ jobs:
           - stable-2.10
           - stable-2.11
           - stable-2.12
+          - stable-2.13
           - devel
     steps:
 
@@ -54,7 +55,7 @@ jobs:
             TEST_INVOCATION="sanity --docker ${{ matrix.test_container }} -v --color ${{ github.event_name != 'schedule' && '--coverage' || '' }}"
 
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ${{ env.COLLECTION_PATH }}
 
@@ -62,7 +63,7 @@ jobs:
         run: ln -s "${COLLECTION_PATH}/.github" .github
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           # it is just required to run that once as "ansible-test sanity" in the docker image
           # will run on all python versions it supports.
@@ -94,7 +95,7 @@ jobs:
 
       - name: Upload ${{ github.job }} coverage reports
         if: ${{ github.event_name != 'schedule' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: coverage=${{ github.job }}=ansible_${{ matrix.ansible }}=data
           path: ${{ env.COLLECTION_PATH }}/tests/output/reports/
@@ -118,6 +119,7 @@ jobs:
           - stable-2.10
           - stable-2.11
           - stable-2.12
+          - stable-2.13
           - devel
 
     steps:
@@ -129,7 +131,7 @@ jobs:
             TEST_INVOCATION="units --color --docker ${{ matrix.test_container }} ${{ github.event_name != 'schedule' && '--coverage' || '' }}"
 
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ${{ env.COLLECTION_PATH }}
 
@@ -137,7 +139,7 @@ jobs:
         run: ln -s "${COLLECTION_PATH}/.github" .github
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           # it is just required to run that once as "ansible-test units" in the docker image
           # will run on all python versions it supports.
@@ -166,7 +168,7 @@ jobs:
 
       - name: Upload ${{ github.job }} coverage reports
         if: ${{ github.event_name != 'schedule' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: coverage=${{ github.job }}=ansible_${{ matrix.ansible }}=data
           path: ${{ env.COLLECTION_PATH }}/tests/output/reports/
@@ -193,6 +195,7 @@ jobs:
           - stable-2.10
           - stable-2.11
           - stable-2.12
+          - stable-2.13
           - devel
         python:
           - '3.6'
@@ -221,7 +224,7 @@ jobs:
             TEST_INVOCATION="integration -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --docker ${{ matrix.test_container }} ${{ github.event_name != 'schedule' && '--coverage' || '' }} --docker-network hashi_vault_default"
 
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ${{ env.COLLECTION_PATH }}
 
@@ -229,7 +232,7 @@ jobs:
         run: ln -s "${COLLECTION_PATH}/.github" .github
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.8
 
@@ -252,10 +255,10 @@ jobs:
           working-directory: ${{ env.COLLECTION_PATH }}
           ansible-test-invocation: ${{ env.TEST_INVOCATION }}
 
-      - name: Set Vault Version (first)
+      - name: Set Vault Version (older)
         uses: briantist/ezenv@v1
         with:
-          env: VAULT_VERSION=${{ fromJSON(steps.vault_versions.outputs.versions)[0] }}
+          env: VAULT_VERSION=${{ fromJSON(steps.vault_versions.outputs.versions)[1] }}
 
       - name: Prepare docker dependencies (Vault ${{ env.VAULT_VERSION }})
         run: ./setup.sh -e vault_version=${VAULT_VERSION}
@@ -265,10 +268,10 @@ jobs:
         run: ansible-test ${{ env.TEST_INVOCATION }}
         working-directory: ${{ env.COLLECTION_PATH }}
 
-      - name: Set Vault Version (second)
+      - name: Set Vault Version (newer)
         uses: briantist/ezenv@v1
         with:
-          env: VAULT_VERSION=${{ fromJSON(steps.vault_versions.outputs.versions)[1] }}
+          env: VAULT_VERSION=${{ fromJSON(steps.vault_versions.outputs.versions)[0] }}
 
       - name: Prepare docker dependencies (Vault ${{ env.VAULT_VERSION }})
         run: ./setup.sh -e vault_version=${VAULT_VERSION}
@@ -286,7 +289,7 @@ jobs:
 
       - name: Upload ${{ github.job }} coverage reports
         if: ${{ github.event_name != 'schedule' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: coverage=${{ github.job }}=ansible_${{ matrix.ansible }}=${{ matrix.python }}=data
           path: ${{ env.COLLECTION_PATH }}/tests/output/reports/
@@ -303,7 +306,7 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.12
+          - stable-2.13
         python:
           - 3.9
         runner:
@@ -329,7 +332,7 @@ jobs:
             DOCKER_TEST_INVOCATION="integration -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --docker ${{ matrix.test_container }} ${{ github.event_name != 'schedule' && '--coverage' || '' }}"
 
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ${{ env.COLLECTION_PATH }}
 
@@ -337,7 +340,7 @@ jobs:
         run: ln -s "${COLLECTION_PATH}/.github" .github
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
 
@@ -393,7 +396,7 @@ jobs:
 
       - name: Upload ${{ github.job }} coverage reports
         if: ${{ github.event_name != 'schedule' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: coverage=${{ github.job }}=${{ matrix.runner }}=ansible_${{ matrix.ansible }}=${{ matrix.python }}=data
           path: ${{ env.COLLECTION_PATH }}/tests/output/reports/
@@ -413,10 +416,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: ./cov
 

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -182,7 +182,7 @@ jobs:
 
   integration:
     runs-on: ${{ matrix.runner }}
-    name: I (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }}
+    name: I (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }})
     strategy:
       fail-fast: false
       matrix:
@@ -306,6 +306,7 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
+          - stable-2.12
           - stable-2.13
         python:
           - 3.9
@@ -320,6 +321,15 @@ jobs:
           # - https://github.com/actions/virtual-environments/pull/4010
         test_container:
           - default
+        exclude:
+          # To add to the fragility of testing docker stuff on MacOS,
+          # stable-2.13 test containers crash; unsure of exact cause
+          # but likely due to old versions of the runtimes.
+          # We'll just stick to 2.12 for now, better than nothing.
+          - runner: macos-10.15
+            ansible: stable-2.13
+          - runner: ubuntu-latest
+            ansible: stable-2.12
 
     steps:
       - name: Initialize env vars

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.8
 
@@ -56,6 +56,8 @@ jobs:
 
       - name: Create Release
         id: create_release
+        # TODO: this action is no longer maintained, replace
+        # likely candidate: https://github.com/softprops/action-gh-release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- bump GitHub action major versions (newer Node)
- add `stable-2.13`  (https://github.com/ansible-collections/news-for-maintainers/issues/14), RIP CI execution time 😭 
- reorder Vault versions (Resolves: #225)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- CI Pull Request

