### PR TITLE
implement `token_validate` default change

### DIFF
--- a/changelogs/fragments/258-token_validate-default.yml
+++ b/changelogs/fragments/258-token_validate-default.yml
@@ -1,0 +1,3 @@
+---
+deprecated_features:
+  - token_validate options - the shared auth option ``token_validate`` will change its default from ``True`` to ``False`` in community.hashi_vault version 4.0.0 (https://github.com/ansible-collections/community.hashi_vault/issues/248).

--- a/changelogs/fragments/258-token_validate-default.yml
+++ b/changelogs/fragments/258-token_validate-default.yml
@@ -1,3 +1,3 @@
 ---
 deprecated_features:
-  - token_validate options - the shared auth option ``token_validate`` will change its default from ``True`` to ``False`` in community.hashi_vault version 4.0.0 (https://github.com/ansible-collections/community.hashi_vault/issues/248).
+  - token_validate options - the shared auth option ``token_validate`` will change its default from ``True`` to ``False`` in community.hashi_vault version 4.0.0. The ``vault_login`` lookup and module will keep the default value of ``True`` (https://github.com/ansible-collections/community.hashi_vault/issues/248).

--- a/plugins/doc_fragments/auth.py
+++ b/plugins/doc_fragments/auth.py
@@ -52,8 +52,8 @@ class ModuleDocFragment(object):
         description:
           - For token auth, will perform a C(lookup-self) operation to determine the token's validity before using it.
           - Disable if your token does not have the C(lookup-self) capability.
-          - The default value is C(True).
-          - The default value will change to C(False) in version 4.0.0.
+          - The default value is C(true).
+          - The default value will change to C(false) in version 4.0.0.
         type: bool
         version_added: 0.2.0
       username:

--- a/plugins/doc_fragments/auth.py
+++ b/plugins/doc_fragments/auth.py
@@ -52,8 +52,9 @@ class ModuleDocFragment(object):
         description:
           - For token auth, will perform a C(lookup-self) operation to determine the token's validity before using it.
           - Disable if your token does not have the C(lookup-self) capability.
+          - The default value is C(True).
+          - The default value will change to C(False) in version 4.0.0.
         type: bool
-        default: true
         version_added: 0.2.0
       username:
         description: Authentication user name.

--- a/plugins/lookup/vault_login.py
+++ b/plugins/lookup/vault_login.py
@@ -40,7 +40,13 @@ DOCUMENTATION = """
       description: This is unused and any terms supplied will be ignored.
       type: str
       required: false
+    token_validate:
+      description:
+        - For token auth, will perform a C(lookup-self) operation to determine the token's validity before using it.
+        - Disable if your token does not have the C(lookup-self) capability.
+      default: true
 """
+# TODO: remove token_validate description in 4.0.0 when it will match the doc frag description.
 
 EXAMPLES = """
 - name: Set a fact with a lookup result

--- a/plugins/module_utils/_auth_method_approle.py
+++ b/plugins/module_utils/_auth_method_approle.py
@@ -22,8 +22,8 @@ class HashiVaultAuthMethodApprole(HashiVaultAuthMethodBase):
     NAME = 'approle'
     OPTIONS = ['role_id', 'secret_id', 'mount_point']
 
-    def __init__(self, option_adapter, warning_callback):
-        super(HashiVaultAuthMethodApprole, self).__init__(option_adapter, warning_callback)
+    def __init__(self, option_adapter, warning_callback, deprecate_callback):
+        super(HashiVaultAuthMethodApprole, self).__init__(option_adapter, warning_callback, deprecate_callback)
 
     def validate(self):
         self.validate_by_required_fields('role_id')

--- a/plugins/module_utils/_auth_method_aws_iam.py
+++ b/plugins/module_utils/_auth_method_aws_iam.py
@@ -33,8 +33,8 @@ class HashiVaultAuthMethodAwsIam(HashiVaultAuthMethodBase):
         'role_id',
     ]
 
-    def __init__(self, option_adapter, warning_callback):
-        super(HashiVaultAuthMethodAwsIam, self).__init__(option_adapter, warning_callback)
+    def __init__(self, option_adapter, warning_callback, deprecate_callback):
+        super(HashiVaultAuthMethodAwsIam, self).__init__(option_adapter, warning_callback, deprecate_callback)
 
     def validate(self):
         params = {

--- a/plugins/module_utils/_auth_method_cert.py
+++ b/plugins/module_utils/_auth_method_cert.py
@@ -14,8 +14,8 @@ class HashiVaultAuthMethodCert(HashiVaultAuthMethodBase):
     NAME = "cert"
     OPTIONS = ["cert_auth_public_key", "cert_auth_private_key", "mount_point", "role_id"]
 
-    def __init__(self, option_adapter, warning_callback):
-        super(HashiVaultAuthMethodCert, self).__init__(option_adapter, warning_callback)
+    def __init__(self, option_adapter, warning_callback, deprecate_callback):
+        super(HashiVaultAuthMethodCert, self).__init__(option_adapter, warning_callback, deprecate_callback)
 
     def validate(self):
         self.validate_by_required_fields("cert_auth_public_key", "cert_auth_private_key")

--- a/plugins/module_utils/_auth_method_jwt.py
+++ b/plugins/module_utils/_auth_method_jwt.py
@@ -22,8 +22,8 @@ class HashiVaultAuthMethodJwt(HashiVaultAuthMethodBase):
     NAME = 'jwt'
     OPTIONS = ['jwt', 'role_id', 'mount_point']
 
-    def __init__(self, option_adapter, warning_callback):
-        super(HashiVaultAuthMethodJwt, self).__init__(option_adapter, warning_callback)
+    def __init__(self, option_adapter, warning_callback, deprecate_callback):
+        super(HashiVaultAuthMethodJwt, self).__init__(option_adapter, warning_callback, deprecate_callback)
 
     def validate(self):
         self.validate_by_required_fields('role_id', 'jwt')

--- a/plugins/module_utils/_auth_method_ldap.py
+++ b/plugins/module_utils/_auth_method_ldap.py
@@ -22,8 +22,8 @@ class HashiVaultAuthMethodLdap(HashiVaultAuthMethodBase):
     NAME = 'ldap'
     OPTIONS = ['username', 'password', 'mount_point']
 
-    def __init__(self, option_adapter, warning_callback):
-        super(HashiVaultAuthMethodLdap, self).__init__(option_adapter, warning_callback)
+    def __init__(self, option_adapter, warning_callback, deprecate_callback):
+        super(HashiVaultAuthMethodLdap, self).__init__(option_adapter, warning_callback, deprecate_callback)
 
     def validate(self):
         self.validate_by_required_fields('username', 'password')

--- a/plugins/module_utils/_auth_method_none.py
+++ b/plugins/module_utils/_auth_method_none.py
@@ -22,8 +22,8 @@ class HashiVaultAuthMethodNone(HashiVaultAuthMethodBase):
     NAME = 'none'
     OPTIONS = []
 
-    def __init__(self, option_adapter, warning_callback):
-        super(HashiVaultAuthMethodNone, self).__init__(option_adapter, warning_callback)
+    def __init__(self, option_adapter, warning_callback, deprecate_callback):
+        super(HashiVaultAuthMethodNone, self).__init__(option_adapter, warning_callback, deprecate_callback)
 
     def validate(self):
         pass

--- a/plugins/module_utils/_auth_method_token.py
+++ b/plugins/module_utils/_auth_method_token.py
@@ -32,8 +32,8 @@ class HashiVaultAuthMethodToken(HashiVaultAuthMethodBase):
         'token_path': dict(env=['HOME']),
     }
 
-    def __init__(self, option_adapter, warning_callback):
-        super(HashiVaultAuthMethodToken, self).__init__(option_adapter, warning_callback)
+    def __init__(self, option_adapter, warning_callback, deprecate_callback):
+        super(HashiVaultAuthMethodToken, self).__init__(option_adapter, warning_callback, deprecate_callback)
 
     def _simulate_login_response(self, token, lookup_response=None):
         '''returns a similar structure to a login method's return, optionally incorporating a lookup-self response'''

--- a/plugins/module_utils/_auth_method_token.py
+++ b/plugins/module_utils/_auth_method_token.py
@@ -76,6 +76,14 @@ class HashiVaultAuthMethodToken(HashiVaultAuthMethodBase):
                 with open(token_filename) as token_file:
                     self._options.set_option('token', token_file.read().strip())
 
+        if self._options.get_option_default('token_validate') is None:
+            self._options.set_option('token_validate', True)
+            self.deprecate(
+                "The default value for 'token_validate' will change from True to False.",
+                version='4.0.0',
+                collection_name='community.hashi_vault'
+            )
+
         if self._options.get_option_default('token') is None:
             raise HashiVaultValueError("No Vault Token specified or discovered.")
 

--- a/plugins/module_utils/_auth_method_userpass.py
+++ b/plugins/module_utils/_auth_method_userpass.py
@@ -22,8 +22,8 @@ class HashiVaultAuthMethodUserpass(HashiVaultAuthMethodBase):
     NAME = 'userpass'
     OPTIONS = ['username', 'password', 'mount_point']
 
-    def __init__(self, option_adapter, warning_callback):
-        super(HashiVaultAuthMethodUserpass, self).__init__(option_adapter, warning_callback)
+    def __init__(self, option_adapter, warning_callback, deprecate_callback):
+        super(HashiVaultAuthMethodUserpass, self).__init__(option_adapter, warning_callback, deprecate_callback)
 
     def validate(self):
         self.validate_by_required_fields('username', 'password')

--- a/plugins/module_utils/_authenticator.py
+++ b/plugins/module_utils/_authenticator.py
@@ -82,9 +82,10 @@ class HashiVaultAuthenticator():
         # TODO: remove in 3.0.0
         if method == 'aws_iam_login':
             method = 'aws_iam'
-            self.warn(
-                "[DEPRECATION WARNING]: auth method 'aws_iam_login' is renamed to 'aws_iam'. "
-                "The 'aws_iam_login' name will be removed in community.hashi_vault 3.0.0."
+            self.deprecate(
+                message="auth method 'aws_iam_login' is renamed to 'aws_iam'.",
+                version='3.0.0',
+                collection_name='community.hashi_vault'
             )
 
         try:

--- a/plugins/module_utils/_authenticator.py
+++ b/plugins/module_utils/_authenticator.py
@@ -41,7 +41,8 @@ class HashiVaultAuthenticator():
         token=dict(type='str', no_log=True, default=None),
         token_path=dict(type='str', default=None, no_log=False),
         token_file=dict(type='str', default='.vault-token'),
-        token_validate=dict(type='bool', default=True),
+        # TODO: token_validate default becomes False in 4.0.0
+        token_validate=dict(type='bool'),
         username=dict(type='str'),
         password=dict(type='str', no_log=True),
         role_id=dict(type='str'),

--- a/plugins/module_utils/_authenticator.py
+++ b/plugins/module_utils/_authenticator.py
@@ -57,22 +57,23 @@ class HashiVaultAuthenticator():
         cert_auth_public_key=dict(type='path'),
     )
 
-    def __init__(self, option_adapter, warning_callback):
+    def __init__(self, option_adapter, warning_callback, deprecate_callback):
         self._options = option_adapter
         self._selector = {
             # please keep this list in alphabetical order of auth method name
             # so that it's easier to scan and see at a glance that a given auth method is present or absent
-            'approle': HashiVaultAuthMethodApprole(option_adapter, warning_callback),
-            'aws_iam': HashiVaultAuthMethodAwsIam(option_adapter, warning_callback),
-            'cert': HashiVaultAuthMethodCert(option_adapter, warning_callback),
-            'jwt': HashiVaultAuthMethodJwt(option_adapter, warning_callback),
-            'ldap': HashiVaultAuthMethodLdap(option_adapter, warning_callback),
-            'none': HashiVaultAuthMethodNone(option_adapter, warning_callback),
-            'token': HashiVaultAuthMethodToken(option_adapter, warning_callback),
-            'userpass': HashiVaultAuthMethodUserpass(option_adapter, warning_callback),
+            'approle': HashiVaultAuthMethodApprole(option_adapter, warning_callback, deprecate_callback),
+            'aws_iam': HashiVaultAuthMethodAwsIam(option_adapter, warning_callback, deprecate_callback),
+            'cert': HashiVaultAuthMethodCert(option_adapter, warning_callback, deprecate_callback),
+            'jwt': HashiVaultAuthMethodJwt(option_adapter, warning_callback, deprecate_callback),
+            'ldap': HashiVaultAuthMethodLdap(option_adapter, warning_callback, deprecate_callback),
+            'none': HashiVaultAuthMethodNone(option_adapter, warning_callback, deprecate_callback),
+            'token': HashiVaultAuthMethodToken(option_adapter, warning_callback, deprecate_callback),
+            'userpass': HashiVaultAuthMethodUserpass(option_adapter, warning_callback, deprecate_callback),
         }
 
         self.warn = warning_callback
+        self.deprecate = deprecate_callback
 
     def _get_method_object(self, method=None):
         if method is None:

--- a/plugins/module_utils/_hashi_vault_common.py
+++ b/plugins/module_utils/_hashi_vault_common.py
@@ -224,9 +224,10 @@ class HashiVaultOptionGroupBase:
 class HashiVaultAuthMethodBase(HashiVaultOptionGroupBase):
     '''Base class for individual auth method implementations'''
 
-    def __init__(self, option_adapter, warning_callback):
+    def __init__(self, option_adapter, warning_callback, deprecate_callback):
         super(HashiVaultAuthMethodBase, self).__init__(option_adapter)
         self._warner = warning_callback
+        self._deprecator = deprecate_callback
 
     def validate(self):
         '''Validates the given auth method as much as possible without calling Vault.'''
@@ -244,3 +245,6 @@ class HashiVaultAuthMethodBase(HashiVaultOptionGroupBase):
 
     def warn(self, message):
         self._warner(message)
+
+    def deprecate(self, message, version=None, date=None, collection_name=None):
+        self._deprecator(message, version=version, date=date, collection_name=collection_name)

--- a/plugins/module_utils/_hashi_vault_module.py
+++ b/plugins/module_utils/_hashi_vault_module.py
@@ -33,7 +33,7 @@ class HashiVaultModule(AnsibleModule):
         self.helper = HashiVaultHelper()
         self.adapter = HashiVaultOptionAdapter.from_dict(self.params)
         self.connection_options = HashiVaultConnectionOptions(option_adapter=self.adapter, retry_callback_generator=callback)
-        self.authenticator = HashiVaultAuthenticator(option_adapter=self.adapter, warning_callback=self.warn)
+        self.authenticator = HashiVaultAuthenticator(option_adapter=self.adapter, warning_callback=self.warn, deprecate_callback=self.deprecate)
 
     @classmethod
     def generate_argspec(cls, **kwargs):

--- a/plugins/modules/vault_login.py
+++ b/plugins/modules/vault_login.py
@@ -38,8 +38,14 @@ DOCUMENTATION = """
     - "In check mode, this module will not perform a login, and will instead return a basic structure with an empty token.
       However this may not be useful if the token is required for follow on tasks.
       It may be better to use this module with C(check_mode=no) in order to have a valid token that can be used."
-  options: {}
+  options:
+    token_validate:
+      description:
+        - For token auth, will perform a C(lookup-self) operation to determine the token's validity before using it.
+        - Disable if your token does not have the C(lookup-self) capability.
+      default: true
 """
+# TODO: remove token_validate description in 4.0.0 when it will match the doc frag description.
 
 EXAMPLES = """
 - name: Login and use the resulting token
@@ -112,7 +118,12 @@ def run_module():
     argspec = HashiVaultModule.generate_argspec(
         # we override this from the shared argspec in order to turn off no_log
         # otherwise we would not be able to return the input token value
-        token=dict(type='str', no_log=False, default=None)
+        token=dict(type='str', no_log=False, default=None),
+
+        # we override this from the shared argspec because the default for
+        # this module should be True, which will differ from the rest of the
+        # collection after 4.0.0.
+        token_validate=dict(type='bool', default=True)
     )
 
     module = HashiVaultModule(

--- a/plugins/plugin_utils/_hashi_vault_plugin.py
+++ b/plugins/plugin_utils/_hashi_vault_plugin.py
@@ -34,7 +34,7 @@ class HashiVaultPlugin(AnsiblePlugin):
         self.helper = HashiVaultHelper()
         self._options_adapter = HashiVaultOptionAdapter.from_ansible_plugin(self)
         self.connection_options = HashiVaultConnectionOptions(self._options_adapter, self._generate_retry_callback)
-        self.authenticator = HashiVaultAuthenticator(self._options_adapter, display.warning)
+        self.authenticator = HashiVaultAuthenticator(self._options_adapter, display.warning, display.deprecated)
 
     def _generate_retry_callback(self, retry_action):
         '''returns a Retry callback function for plugins'''

--- a/tests/integration/targets/auth_token/tasks/token_test_controller.yml
+++ b/tests/integration/targets/auth_token/tasks/token_test_controller.yml
@@ -11,6 +11,10 @@
         ansible_hashi_vault_token: '{{ user_token }}'
 
     - name: Authenticate with a 'no default policy' token (failure expected)
+      # vars:
+      #   ansible_hashi_vault_token_validate: true
+      # This will fail when the default changes in 4.0.0. Uncomment above.
+      # https://github.com/ansible-collections/community.hashi_vault/issues/248
       set_fact:
         response: "{{ lookup('vault_test_auth', want_exception=true) }}"
 
@@ -22,6 +26,8 @@
     - name: Authenticate with 'no default policy' token - with no validation
       vars:
         ansible_hashi_vault_token_validate: false
+      # After 4.0.0, let's let this one use the default value and unset the above.
+      # https://github.com/ansible-collections/community.hashi_vault/issues/248
       set_fact:
         response: "{{ lookup('vault_test_auth') }}"
 

--- a/tests/integration/targets/auth_token/tasks/token_test_target.yml
+++ b/tests/integration/targets/auth_token/tasks/token_test_target.yml
@@ -11,6 +11,9 @@
     - name: Authenticate with a 'no default policy' token (failure expected)
       register: response
       vault_test_auth:
+        # token_validate: true
+        # This will fail when the default changes in 4.0.0. Uncomment above.
+        # https://github.com/ansible-collections/community.hashi_vault/issues/248
         want_exception: true
 
     - assert:
@@ -22,6 +25,8 @@
       register: response
       vault_test_auth:
         token_validate: false
+        # After 4.0.0, let's let this one use the default value and unset the above.
+        # https://github.com/ansible-collections/community.hashi_vault/issues/248
 
     - assert:
         that: response.login.auth.client_token == user_token

--- a/tests/unit/plugins/module_utils/authentication/conftest.py
+++ b/tests/unit/plugins/module_utils/authentication/conftest.py
@@ -26,8 +26,8 @@ class HashiVaultAuthMethodFake(HashiVaultAuthMethodBase):
     NAME = 'fake'
     OPTIONS = []
 
-    def __init__(self, option_adapter, warning_callback):
-        super(HashiVaultAuthMethodFake, self).__init__(option_adapter, warning_callback)
+    def __init__(self, option_adapter, warning_callback, deprecate_callback):
+        super(HashiVaultAuthMethodFake, self).__init__(option_adapter, warning_callback, deprecate_callback)
 
     validate = mock.MagicMock()
     authenticate = mock.MagicMock()
@@ -44,8 +44,8 @@ def adapter(option_dict):
 
 
 @pytest.fixture
-def fake_auth_class(adapter):
-    return HashiVaultAuthMethodFake(adapter, mock.MagicMock())
+def fake_auth_class(adapter, warner, deprecator):
+    return HashiVaultAuthMethodFake(adapter, warner, deprecator)
 
 
 @pytest.fixture
@@ -55,6 +55,11 @@ def client():
 
 @pytest.fixture
 def warner():
+    return mock.MagicMock()
+
+
+@pytest.fixture
+def deprecator():
     return mock.MagicMock()
 
 

--- a/tests/unit/plugins/module_utils/authentication/test_auth_approle.py
+++ b/tests/unit/plugins/module_utils/authentication/test_auth_approle.py
@@ -40,8 +40,8 @@ def role_id():
 
 
 @pytest.fixture
-def auth_approle(adapter, warner):
-    return HashiVaultAuthMethodApprole(adapter, warner)
+def auth_approle(adapter, warner, deprecator):
+    return HashiVaultAuthMethodApprole(adapter, warner, deprecator)
 
 
 @pytest.fixture

--- a/tests/unit/plugins/module_utils/authentication/test_auth_aws_iam.py
+++ b/tests/unit/plugins/module_utils/authentication/test_auth_aws_iam.py
@@ -50,8 +50,8 @@ def aws_session_token():
 
 
 @pytest.fixture
-def auth_aws_iam(adapter, warner):
-    return HashiVaultAuthMethodAwsIam(adapter, warner)
+def auth_aws_iam(adapter, warner, deprecator):
+    return HashiVaultAuthMethodAwsIam(adapter, warner, deprecator)
 
 
 @pytest.fixture

--- a/tests/unit/plugins/module_utils/authentication/test_auth_cert.py
+++ b/tests/unit/plugins/module_utils/authentication/test_auth_cert.py
@@ -20,8 +20,8 @@ from ansible_collections.community.hashi_vault.plugins.module_utils._hashi_vault
 
 
 @pytest.fixture
-def auth_cert(adapter, warner):
-    return HashiVaultAuthMethodCert(adapter, warner)
+def auth_cert(adapter, warner, deprecator):
+    return HashiVaultAuthMethodCert(adapter, warner, deprecator)
 
 
 @pytest.fixture

--- a/tests/unit/plugins/module_utils/authentication/test_auth_jwt.py
+++ b/tests/unit/plugins/module_utils/authentication/test_auth_jwt.py
@@ -40,8 +40,8 @@ def role_id():
 
 
 @pytest.fixture
-def auth_jwt(adapter, warner):
-    return HashiVaultAuthMethodJwt(adapter, warner)
+def auth_jwt(adapter, warner, deprecator):
+    return HashiVaultAuthMethodJwt(adapter, warner, deprecator)
 
 
 @pytest.fixture

--- a/tests/unit/plugins/module_utils/authentication/test_auth_ldap.py
+++ b/tests/unit/plugins/module_utils/authentication/test_auth_ldap.py
@@ -40,8 +40,8 @@ def ldap_password():
 
 
 @pytest.fixture
-def auth_ldap(adapter, warner):
-    return HashiVaultAuthMethodLdap(adapter, warner)
+def auth_ldap(adapter, warner, deprecator):
+    return HashiVaultAuthMethodLdap(adapter, warner, deprecator)
 
 
 @pytest.fixture

--- a/tests/unit/plugins/module_utils/authentication/test_auth_none.py
+++ b/tests/unit/plugins/module_utils/authentication/test_auth_none.py
@@ -15,8 +15,8 @@ from ansible_collections.community.hashi_vault.plugins.module_utils._hashi_vault
 
 
 @pytest.fixture
-def auth_none(adapter, warner):
-    return HashiVaultAuthMethodNone(adapter, warner)
+def auth_none(adapter, warner, deprecator):
+    return HashiVaultAuthMethodNone(adapter, warner, deprecator)
 
 
 class TestAuthNone(object):

--- a/tests/unit/plugins/module_utils/authentication/test_auth_token.py
+++ b/tests/unit/plugins/module_utils/authentication/test_auth_token.py
@@ -45,8 +45,8 @@ def token():
 
 
 @pytest.fixture
-def auth_token(adapter, warner):
-    return HashiVaultAuthMethodToken(adapter, warner)
+def auth_token(adapter, warner, deprecator):
+    return HashiVaultAuthMethodToken(adapter, warner, deprecator)
 
 
 @pytest.fixture(params=['lookup-self_with_meta.json', 'lookup-self_without_meta.json'])

--- a/tests/unit/plugins/module_utils/authentication/test_auth_userpass.py
+++ b/tests/unit/plugins/module_utils/authentication/test_auth_userpass.py
@@ -40,8 +40,8 @@ def userpass_username():
 
 
 @pytest.fixture
-def auth_userpass(adapter, warner):
-    return HashiVaultAuthMethodUserpass(adapter, warner)
+def auth_userpass(adapter, warner, deprecator):
+    return HashiVaultAuthMethodUserpass(adapter, warner, deprecator)
 
 
 @pytest.fixture

--- a/tests/unit/plugins/module_utils/authentication/test_hashi_vault_auth_method_base.py
+++ b/tests/unit/plugins/module_utils/authentication/test_hashi_vault_auth_method_base.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import sys
 import pytest
 
 from ansible_collections.community.hashi_vault.tests.unit.compat import mock
@@ -18,8 +17,8 @@ from ansible_collections.community.hashi_vault.plugins.module_utils._hashi_vault
 
 
 @pytest.fixture
-def auth_base(adapter, warner):
-    return HashiVaultAuthMethodBase(adapter, warner)
+def auth_base(adapter, warner, deprecator):
+    return HashiVaultAuthMethodBase(adapter, warner, deprecator)
 
 
 class TestHashiVaultAuthMethodBase(object):
@@ -64,3 +63,13 @@ class TestHashiVaultAuthMethodBase(object):
         auth_base.warn(msg)
 
         warner.assert_called_once_with(msg)
+
+    @pytest.mark.parametrize('version', [None, '0.99.7'])
+    @pytest.mark.parametrize('date', [None, '2022'])
+    @pytest.mark.parametrize('collection_name', [None, 'ns.col'])
+    def test_deprecate_callback(self, auth_base, deprecator, version, date, collection_name):
+        msg = 'warning msg'
+
+        auth_base.deprecate(msg, version, date, collection_name)
+
+        deprecator.assert_called_once_with(msg, version=version, date=date, collection_name=collection_name)

--- a/tests/unit/plugins/module_utils/authentication/test_hashi_vault_authenticator.py
+++ b/tests/unit/plugins/module_utils/authentication/test_hashi_vault_authenticator.py
@@ -70,11 +70,12 @@ class TestHashiVaultAuthenticator(object):
 
     # TODO: remove in 3.0.0 when aws_iam_login name is removed
     # https://github.com/ansible-collections/community.hashi_vault/pull/193
-    def test_get_method_object_deprecated_aws_iam_login(self, authenticator, warner):
+    def test_get_method_object_deprecated_aws_iam_login(self, authenticator, deprecator):
         obj = authenticator._get_method_object('aws_iam_login')
 
         assert obj == authenticator._selector['aws_iam']
-        warner.assert_called_once_with(
-            "[DEPRECATION WARNING]: auth method 'aws_iam_login' is renamed to 'aws_iam'. "
-            "The 'aws_iam_login' name will be removed in community.hashi_vault 3.0.0."
+        deprecator.assert_called_once_with(
+            message="auth method 'aws_iam_login' is renamed to 'aws_iam'.",
+            version='3.0.0',
+            collection_name='community.hashi_vault'
         )

--- a/tests/unit/plugins/module_utils/authentication/test_hashi_vault_authenticator.py
+++ b/tests/unit/plugins/module_utils/authentication/test_hashi_vault_authenticator.py
@@ -13,13 +13,8 @@ from ansible_collections.community.hashi_vault.plugins.module_utils._authenticat
 
 
 @pytest.fixture
-def mock_warner():
-    return mock.MagicMock()
-
-
-@pytest.fixture
-def authenticator(fake_auth_class, adapter, mock_warner):
-    a = HashiVaultAuthenticator(adapter, mock_warner)
+def authenticator(fake_auth_class, adapter, warner, deprecator):
+    a = HashiVaultAuthenticator(adapter, warner, deprecator)
     a._selector.update({fake_auth_class.NAME: fake_auth_class})
 
     return a
@@ -75,11 +70,11 @@ class TestHashiVaultAuthenticator(object):
 
     # TODO: remove in 3.0.0 when aws_iam_login name is removed
     # https://github.com/ansible-collections/community.hashi_vault/pull/193
-    def test_get_method_object_deprecated_aws_iam_login(self, authenticator, mock_warner):
+    def test_get_method_object_deprecated_aws_iam_login(self, authenticator, warner):
         obj = authenticator._get_method_object('aws_iam_login')
 
         assert obj == authenticator._selector['aws_iam']
-        mock_warner.assert_called_once_with(
+        warner.assert_called_once_with(
             "[DEPRECATION WARNING]: auth method 'aws_iam_login' is renamed to 'aws_iam'. "
             "The 'aws_iam_login' name will be removed in community.hashi_vault 3.0.0."
         )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Related: #248

Announce that the default value for `token_validate` is changing in 4.0.0.

Will repeat this PR in the release for 3.0.0 so that it's announced in the porting guide for 4.0.0 too.

### Which changelog section?

I used `deprecated_features` but I don't think it's quite right. Nothing is being deprecated, just changed.

I'm trying to consider if `breaking_changes` is more appropriate, either now for the announcements, in 4.0.0 for the actual change, or even both?

`major_features` feels too major. For the actual change, `removed_features` doesn't really make sense.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
