### PR TITLE
Remove `aws_iam_login` name

### DIFF
--- a/changelogs/fragments/194-remove-aws_iam_login.yml
+++ b/changelogs/fragments/194-remove-aws_iam_login.yml
@@ -1,0 +1,3 @@
+---
+removed_features:
+  - aws_iam auth - the deprecated alias ``aws_iam_login`` for the ``aws_iam`` value of the ``auth_method`` option has been removed (https://github.com/ansible-collections/community.hashi_vault/issues/194).

--- a/plugins/doc_fragments/auth.py
+++ b/plugins/doc_fragments/auth.py
@@ -16,14 +16,13 @@ class ModuleDocFragment(object):
           - Authentication method to be used.
           - C(none) auth method was added in collection version C(1.2.0).
           - C(cert) auth method was added in collection version C(1.4.0).
-          - C(aws_iam_login) was renamed C(aws_iam) in collection version C(2.1.0). The old name will be removed in C(3.0.0).
+          - C(aws_iam_login) was renamed C(aws_iam) in collection version C(2.1.0) and was removed in C(3.0.0).
         choices:
           - token
           - userpass
           - ldap
           - approle
           - aws_iam
-          - aws_iam_login
           - jwt
           - cert
           - none

--- a/plugins/module_utils/_authenticator.py
+++ b/plugins/module_utils/_authenticator.py
@@ -32,7 +32,6 @@ class HashiVaultAuthenticator():
             'ldap',
             'approle',
             'aws_iam',
-            'aws_iam_login',
             'jwt',
             'cert',
             'none',
@@ -79,15 +78,6 @@ class HashiVaultAuthenticator():
     def _get_method_object(self, method=None):
         if method is None:
             method = self._options.get_option('auth_method')
-
-        # TODO: remove in 3.0.0
-        if method == 'aws_iam_login':
-            method = 'aws_iam'
-            self.deprecate(
-                message="auth method 'aws_iam_login' is renamed to 'aws_iam'.",
-                version='3.0.0',
-                collection_name='community.hashi_vault'
-            )
 
         try:
             o_method = self._selector[method]

--- a/tests/unit/plugins/module_utils/authentication/test_hashi_vault_authenticator.py
+++ b/tests/unit/plugins/module_utils/authentication/test_hashi_vault_authenticator.py
@@ -67,15 +67,3 @@ class TestHashiVaultAuthenticator(object):
         obj = authenticator._get_method_object()
 
         assert isinstance(obj, type(fake_auth_class))
-
-    # TODO: remove in 3.0.0 when aws_iam_login name is removed
-    # https://github.com/ansible-collections/community.hashi_vault/pull/193
-    def test_get_method_object_deprecated_aws_iam_login(self, authenticator, deprecator):
-        obj = authenticator._get_method_object('aws_iam_login')
-
-        assert obj == authenticator._selector['aws_iam']
-        deprecator.assert_called_once_with(
-            message="auth method 'aws_iam_login' is renamed to 'aws_iam'.",
-            version='3.0.0',
-            collection_name='community.hashi_vault'
-        )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove the deprecated `aws_iam_login` name for the `aws_iam` auth method.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Resolves #194 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Deprecation/Removal

