### PR TITLE
announce `token_validate` default change in 3.0.0

### DIFF
--- a/changelogs/fragments/248-token_validate-change-default.yml
+++ b/changelogs/fragments/248-token_validate-change-default.yml
@@ -1,0 +1,3 @@
+---
+deprecated_features:
+  - token_validate options - the shared auth option ``token_validate`` will change its default from ``True`` to ``False`` in community.hashi_vault version 4.0.0. The ``vault_login`` lookup and module will keep the default value of ``True`` (https://github.com/ansible-collections/community.hashi_vault/issues/248).

--- a/changelogs/fragments/248-token_validate-change-default.yml
+++ b/changelogs/fragments/248-token_validate-change-default.yml
@@ -1,3 +1,3 @@
 ---
 deprecated_features:
-  - token_validate options - the shared auth option ``token_validate`` will change its default from ``True`` to ``False`` in community.hashi_vault version 4.0.0. The ``vault_login`` lookup and module will keep the default value of ``True`` (https://github.com/ansible-collections/community.hashi_vault/issues/248).
+  - token_validate options - the shared auth option ``token_validate`` will change its default from ``true`` to ``false`` in community.hashi_vault version 4.0.0. The ``vault_login`` lookup and module will keep the default value of ``true`` (https://github.com/ansible-collections/community.hashi_vault/issues/248).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Related:
- #248 

This was announced in 2.5.0, this PR is adding the announcement in 3.0.0.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- deprecation/removal
