### PR TITLE
Deprecate incorrect `vault_kv2_get` lookup default

### DIFF
--- a/changelogs/fragments/279-incorrect-kv2-lookup-default.yml
+++ b/changelogs/fragments/279-incorrect-kv2-lookup-default.yml
@@ -1,0 +1,3 @@
+---
+deprecated_features:
+  - vault_kv2_get lookup - the ``engine_mount_point option`` in the ``vault_kv2_get`` lookup only will change its default from ``kv`` to ``secret`` in community.hashi_vault version 4.0.0 (https://github.com/ansible-collections/community.hashi_vault/issues/279).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: community
 name: hashi_vault
-version: 3.1.0
+version: 3.0.1
 readme: README.md
 authors:
   - Julie Davila (@juliedavila) <julie(at)davila.io>

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: community
 name: hashi_vault
-version: 3.0.1
+version: 3.1.0
 readme: README.md
 authors:
   - Julie Davila (@juliedavila) <julie(at)davila.io>


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Implements the deprecation for #279 in advance of the change in 4.0.0.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vault_kv2_get

