### PR TITLE
try macos 12

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -300,7 +300,7 @@ jobs:
           - 3.9
         runner:
           - ubuntu-latest
-          - macos-10.15
+          - macos-12
           # macos-11 will not support virtualbox, so we can't run docker
           # when macos-10.15 support is dropped we will have to stop testing on it
           # unless a solution for docker/virtualbox is found.
@@ -314,8 +314,8 @@ jobs:
           # stable-2.13 test containers crash; unsure of exact cause
           # but likely due to old versions of the runtimes.
           # We'll just stick to 2.12 for now, better than nothing.
-          - runner: macos-10.15
-            ansible: stable-2.13
+          # - runner: macos-10.15
+          #   ansible: stable-2.13
           - runner: ubuntu-latest
             ansible: stable-2.12
 

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -301,12 +301,6 @@ jobs:
         runner:
           - ubuntu-latest
           - macos-12
-          # macos-11 will not support virtualbox, so we can't run docker
-          # when macos-10.15 support is dropped we will have to stop testing on it
-          # unless a solution for docker/virtualbox is found.
-          # See also:
-          # - https://github.com/actions/virtual-environments/issues/4060
-          # - https://github.com/actions/virtual-environments/pull/4010
         test_container:
           - default
         exclude:
@@ -314,8 +308,8 @@ jobs:
           # stable-2.13 test containers crash; unsure of exact cause
           # but likely due to old versions of the runtimes.
           # We'll just stick to 2.12 for now, better than nothing.
-          # - runner: macos-10.15
-          #   ansible: stable-2.13
+          - runner: macos-12
+            ansible: stable-2.13
           - runner: ubuntu-latest
             ansible: stable-2.12
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Resolves #283 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Confirmed macos-12 works, also confirmed that ansible-core 2.13 still doesn't work, so we'll stick to pinning at 2.12.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- CI Pull Request
