### PR TITLE
Fix "Unsafe" token values that originate from lookups

### DIFF
--- a/changelogs/fragments/289-handle-unsafe-strings.yml
+++ b/changelogs/fragments/289-handle-unsafe-strings.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - community.hashi_vault plugins - tokens will be cast to a string type before being sent to ``hvac`` to prevent errors in ``requests`` when values are ``AnsibleUnsafe`` (https://github.com/ansible-collections/community.hashi_vault/issues/289).

--- a/plugins/module_utils/_auth_method_token.py
+++ b/plugins/module_utils/_auth_method_token.py
@@ -89,7 +89,7 @@ class HashiVaultAuthMethodToken(HashiVaultAuthMethodBase):
             raise HashiVaultValueError("No Vault Token specified or discovered.")
 
     def authenticate(self, client, use_token=True, lookup_self=False):
-        token = self._options.get_option('token')
+        token = self._stringify(self._options.get_option('token'))
         validate = self._options.get_option_default('token_validate')
 
         response = None

--- a/plugins/module_utils/_hashi_vault_common.py
+++ b/plugins/module_utils/_hashi_vault_common.py
@@ -65,7 +65,8 @@ class HashiVaultHelper():
         # TODO move hvac checking here?
         pass
 
-    def _stringify(self, input):
+    @staticmethod
+    def _stringify(input):
         return _stringify(input)
 
     def get_vault_client(
@@ -295,5 +296,6 @@ class HashiVaultAuthMethodBase(HashiVaultOptionGroupBase):
     def deprecate(self, message, version=None, date=None, collection_name=None):
         self._deprecator(message, version=version, date=date, collection_name=collection_name)
 
-    def _stringify(self, input):
+    @staticmethod
+    def _stringify(input):
         return _stringify(input)

--- a/tests/unit/plugins/module_utils/authentication/test_hashi_vault_auth_method_base.py
+++ b/tests/unit/plugins/module_utils/authentication/test_hashi_vault_auth_method_base.py
@@ -14,6 +14,7 @@ from ansible_collections.community.hashi_vault.plugins.module_utils._hashi_vault
     HashiVaultAuthMethodBase,
     HashiVaultOptionGroupBase,
     HashiVaultValueError,
+    _stringify,
 )
 
 
@@ -74,3 +75,12 @@ class TestHashiVaultAuthMethodBase(object):
         auth_base.deprecate(msg, version, date, collection_name)
 
         deprecator.assert_called_once_with(msg, version=version, date=date, collection_name=collection_name)
+
+    def test_has_stringify(self, auth_base):
+        v = 'X'
+        wrapper = mock.Mock(wraps=_stringify)
+        with mock.patch('ansible_collections.community.hashi_vault.plugins.module_utils._hashi_vault_common._stringify', wrapper):
+            r = auth_base._stringify(v)
+
+        wrapper.assert_called_once_with(v)
+        assert r == v

--- a/tests/unit/plugins/module_utils/test_hashi_vault_helper.py
+++ b/tests/unit/plugins/module_utils/test_hashi_vault_helper.py
@@ -11,7 +11,10 @@ import os
 import pytest
 
 from ansible_collections.community.hashi_vault.tests.unit.compat import mock
-from ansible_collections.community.hashi_vault.plugins.module_utils._hashi_vault_common import HashiVaultHelper
+from ansible_collections.community.hashi_vault.plugins.module_utils._hashi_vault_common import (
+    HashiVaultHelper,
+    _stringify,
+)
 
 
 @pytest.fixture
@@ -46,3 +49,12 @@ class TestHashiVaultHelper(object):
         client = hashi_vault_helper.get_vault_client(hashi_vault_logout_inferred_token=True)
 
         assert client.token is None
+
+    def test_has_stringify(self, hashi_vault_helper):
+        v = 'X'
+        wrapper = mock.Mock(wraps=_stringify)
+        with mock.patch('ansible_collections.community.hashi_vault.plugins.module_utils._hashi_vault_common._stringify', wrapper):
+            r = hashi_vault_helper._stringify(v)
+
+        wrapper.assert_called_once_with(v)
+        assert r == v, '%r != %r' % (r, v)

--- a/tests/unit/plugins/plugin_utils/authentication/conftest.py
+++ b/tests/unit/plugins/plugin_utils/authentication/conftest.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2022 Brian Scholer (@briantist)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+# pylint: disable=wildcard-import,unused-wildcard-import
+from ...module_utils.authentication.conftest import *

--- a/tests/unit/plugins/plugin_utils/authentication/test_auth_token.py
+++ b/tests/unit/plugins/plugin_utils/authentication/test_auth_token.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 Brian Scholer (@briantist)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from ansible.utils.unsafe_proxy import AnsibleUnsafe, AnsibleUnsafeBytes, AnsibleUnsafeText
+
+from ansible_collections.community.hashi_vault.tests.unit.compat import mock
+
+from ansible_collections.community.hashi_vault.plugins.module_utils._auth_method_token import (
+    HashiVaultAuthMethodToken,
+)
+
+
+@pytest.fixture
+def option_dict():
+    return {
+        'auth_method': 'fake',
+        'token': None,
+        'token_path': None,
+        'token_file': '.vault-token',
+        'token_validate': True,
+    }
+
+
+@pytest.fixture(params=[AnsibleUnsafeBytes(b'ub_opaque'), AnsibleUnsafeText(u'ut_opaque'), b'b_opaque', u't_opaque'])
+def token(request):
+    return request.param
+
+
+@pytest.fixture
+def auth_token(adapter, warner, deprecator):
+    return HashiVaultAuthMethodToken(adapter, warner, deprecator)
+
+
+class TestAuthToken(object):
+
+    def test_auth_token_unsafes(self, auth_token, client, adapter, token):
+        adapter.set_option('token', token)
+        adapter.set_option('token_validate', False)
+
+        wrapper = mock.Mock(wraps=auth_token._stringify)
+
+        with mock.patch.object(auth_token, '_stringify', wrapper):
+            response = auth_token.authenticate(client, use_token=True, lookup_self=False)
+
+        assert isinstance(response['auth']['client_token'], (bytes, type(u''))), repr(response['auth']['client_token'])
+        assert isinstance(client.token, (bytes, type(u''))), repr(client.token)
+        assert not isinstance(response['auth']['client_token'], AnsibleUnsafe), repr(response['auth']['client_token'])
+        assert not isinstance(client.token, AnsibleUnsafe), repr(client.token)

--- a/tests/unit/plugins/plugin_utils/authentication/test_auth_token.py
+++ b/tests/unit/plugins/plugin_utils/authentication/test_auth_token.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2021 Brian Scholer (@briantist)
+# Copyright (c) 2022 Brian Scholer (@briantist)
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/tests/unit/plugins/plugin_utils/test_hashi_vault_common_stringify.py
+++ b/tests/unit/plugins/plugin_utils/test_hashi_vault_common_stringify.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2022 Brian Scholer (@briantist)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from ansible.utils.unsafe_proxy import AnsibleUnsafe, AnsibleUnsafeBytes, AnsibleUnsafeText
+
+from ansible_collections.community.hashi_vault.plugins.module_utils._hashi_vault_common import _stringify
+
+
+@pytest.fixture
+def uvalue():
+    return u'fake123'
+
+
+@pytest.fixture
+def bvalue():
+    return b'fake456'
+
+
+class TestHashiVaultCommonStringify(object):
+    @pytest.mark.parametrize('unsafe', [True, False])
+    def test_stringify_bytes(self, unsafe, bvalue):
+        token = bvalue
+        if unsafe:
+            token = AnsibleUnsafeBytes(token)
+
+        r = _stringify(token)
+
+        assert isinstance(r, bytes)
+        assert not isinstance(r, AnsibleUnsafe)
+
+    @pytest.mark.parametrize('unsafe', [True, False])
+    def test_stringify_unicode(self, unsafe, uvalue):
+        token = uvalue
+        utype = type(token)
+        if unsafe:
+            token = AnsibleUnsafeText(token)
+
+        r = _stringify(token)
+
+        assert isinstance(r, utype)
+        assert not isinstance(r, AnsibleUnsafe)

--- a/tests/unit/plugins/plugin_utils/test_hashi_vault_helper.py
+++ b/tests/unit/plugins/plugin_utils/test_hashi_vault_helper.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2022 Brian Scholer (@briantist)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from ansible.utils.unsafe_proxy import AnsibleUnsafe, AnsibleUnsafeBytes, AnsibleUnsafeText
+
+from ansible_collections.community.hashi_vault.tests.unit.compat import mock
+from ansible_collections.community.hashi_vault.plugins.module_utils._hashi_vault_common import HashiVaultHelper
+
+
+@pytest.fixture
+def hashi_vault_helper():
+    return HashiVaultHelper()
+
+
+@pytest.fixture
+def vault_unicode_token():
+    return u'fake123'
+
+
+@pytest.fixture
+def vault_bytes_token():
+    return b'fake456'
+
+
+@pytest.fixture
+def expected_stringify_candidates():
+    return {
+        'token',
+    }
+
+
+class TestHashiVaultHelper(object):
+    def test_expected_stringify_candidates(self, hashi_vault_helper, expected_stringify_candidates):
+        # If we add more candidates to the set without updating the tests,
+        # this will help us catch that. The purpose is not to simply update
+        # the set in the fixture, but to also add specific tests where appropriate.
+        assert hashi_vault_helper.STRINGIFY_CANDIDATES == expected_stringify_candidates, '%r' % (
+            hashi_vault_helper.STRINGIFY_CANDIDATES ^ expected_stringify_candidates
+        )
+
+    @pytest.mark.parametrize('unsafe', [True, False])
+    def test_stringify_bytes(self, hashi_vault_helper, unsafe, vault_bytes_token):
+        token = vault_bytes_token
+        if unsafe:
+            token = AnsibleUnsafeBytes(token)
+
+        r = hashi_vault_helper._stringify(token)
+
+        assert isinstance(r, bytes)
+        assert not isinstance(r, AnsibleUnsafe)
+
+    @pytest.mark.parametrize('unsafe', [True, False])
+    def test_stringify_unicode(self, hashi_vault_helper, unsafe, vault_unicode_token):
+        token = vault_unicode_token
+        utype = type(token)
+        if unsafe:
+            token = AnsibleUnsafeText(token)
+
+        r = hashi_vault_helper._stringify(token)
+
+        assert isinstance(r, utype)
+        assert not isinstance(r, AnsibleUnsafe)
+
+    @pytest.mark.parametrize('input', [b'one', u'two', AnsibleUnsafeBytes(b'three'), AnsibleUnsafeText(u'four')])
+    @pytest.mark.parametrize('stringify', [True, False])
+    def test_get_vault_client_stringify(self, hashi_vault_helper, expected_stringify_candidates, input, stringify):
+        kwargs = {
+            '__no_candidate': AnsibleUnsafeText(u'value'),
+        }
+        expected_calls = []
+        for k in expected_stringify_candidates:
+            v = '%s_%s' % (k, input)
+            kwargs[k] = v
+            if stringify:
+                expected_calls.append(mock.call(v))
+
+        wrapper = mock.Mock(wraps=hashi_vault_helper._stringify)
+        with mock.patch('hvac.Client'):
+            with mock.patch.object(hashi_vault_helper, '_stringify', wrapper):
+                hashi_vault_helper.get_vault_client(hashi_vault_stringify_args=stringify, **kwargs)
+
+        assert wrapper.call_count == len(expected_calls)
+        wrapper.assert_has_calls(expected_calls)

--- a/tests/unit/plugins/plugin_utils/test_hashi_vault_helper.py
+++ b/tests/unit/plugins/plugin_utils/test_hashi_vault_helper.py
@@ -20,16 +20,6 @@ def hashi_vault_helper():
 
 
 @pytest.fixture
-def vault_unicode_token():
-    return u'fake123'
-
-
-@pytest.fixture
-def vault_bytes_token():
-    return b'fake456'
-
-
-@pytest.fixture
 def expected_stringify_candidates():
     return set(
         'token',

--- a/tests/unit/plugins/plugin_utils/test_hashi_vault_helper.py
+++ b/tests/unit/plugins/plugin_utils/test_hashi_vault_helper.py
@@ -31,9 +31,9 @@ def vault_bytes_token():
 
 @pytest.fixture
 def expected_stringify_candidates():
-    return {
+    return set(
         'token',
-    }
+    )
 
 
 class TestHashiVaultHelper(object):
@@ -44,29 +44,6 @@ class TestHashiVaultHelper(object):
         assert hashi_vault_helper.STRINGIFY_CANDIDATES == expected_stringify_candidates, '%r' % (
             hashi_vault_helper.STRINGIFY_CANDIDATES ^ expected_stringify_candidates
         )
-
-    @pytest.mark.parametrize('unsafe', [True, False])
-    def test_stringify_bytes(self, hashi_vault_helper, unsafe, vault_bytes_token):
-        token = vault_bytes_token
-        if unsafe:
-            token = AnsibleUnsafeBytes(token)
-
-        r = hashi_vault_helper._stringify(token)
-
-        assert isinstance(r, bytes)
-        assert not isinstance(r, AnsibleUnsafe)
-
-    @pytest.mark.parametrize('unsafe', [True, False])
-    def test_stringify_unicode(self, hashi_vault_helper, unsafe, vault_unicode_token):
-        token = vault_unicode_token
-        utype = type(token)
-        if unsafe:
-            token = AnsibleUnsafeText(token)
-
-        r = hashi_vault_helper._stringify(token)
-
-        assert isinstance(r, utype)
-        assert not isinstance(r, AnsibleUnsafe)
 
     @pytest.mark.parametrize('input', [b'one', u'two', AnsibleUnsafeBytes(b'three'), AnsibleUnsafeText(u'four')])
     @pytest.mark.parametrize('stringify', [True, False])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #289

Right now this is only applied to the `token` but the groundwork is in place to apply this to other options as needed. 
The current issue affects things that will end up in headers, like the token.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
_hashi_vault_common

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
- https://github.com/psf/requests/issues/6159
