### PR TITLE
Add HTTP `412` to default retry list

### DIFF
--- a/changelogs/fragments/290-retry-http-412.yml
+++ b/changelogs/fragments/290-retry-http-412.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - community.hashi_vault retries - `HTTP status code 412 <https://www.vaultproject.io/api-docs#412>`__ has been added to the default list of codes to be retried, for the new `Server Side Consistent Token feature <https://www.vaultproject.io/docs/faq/ssct#q-is-there-anything-else-i-need-to-consider-to-achieve-consistency-besides-upgrading-to-vault-1-10>`__ in Vault Enterprise (https://github.com/ansible-collections/community.hashi_vault/issues/290).

--- a/docs/docsite/rst/user_guide.rst
+++ b/docs/docsite/rst/user_guide.rst
@@ -67,6 +67,7 @@ Current Defaults (always check the source code to confirm the defaults in your s
     status_forcelist:
       # https://www.vaultproject.io/api#http-status-codes
       # 429 is usually a "too many requests" status, but in Vault it's the default health status response for standby nodes.
+      - 412 # Precondition failed. Returned on Enterprise when a request can't be processed yet due to some missing eventually consistent data. Should be retried, perhaps with a little backoff.
       - 500 # Internal server error. An internal error has occurred, try again later. If the error persists, report a bug.
       - 502 # A request to Vault required Vault making a request to a third party; the third party responded with an error of some kind.
       - 503 # Vault is down for maintenance or is currently sealed. Try again later.

--- a/plugins/module_utils/_connection_options.py
+++ b/plugins/module_utils/_connection_options.py
@@ -74,9 +74,11 @@ class HashiVaultConnectionOptions(HashiVaultOptionGroupBase):
         'status_forcelist': [
             # https://www.vaultproject.io/api#http-status-codes
             # 429 is usually a "too many requests" status, but in Vault it's the default health status response for standby nodes.
-            500,  # Internal server error. An internal error has occurred, try again later. If the error persists, report a bug.
-            502,  # A request to Vault required Vault making a request to a third party; the third party responded with an error of some kind.
-            503,  # Vault is down for maintenance or is currently sealed. Try again later.
+            412,    # Precondition failed. Returned on Enterprise when a request can't be processed yet due to some missing eventually consistent data.
+                    # Should be retried, perhaps with a little backoff.
+            500,    # Internal server error. An internal error has occurred, try again later. If the error persists, report a bug.
+            502,    # A request to Vault required Vault making a request to a third party; the third party responded with an error of some kind.
+            503,    # Vault is down for maintenance or is currently sealed. Try again later.
         ],
         (
             # this field name changed in 1.26.0, and in the interest of supporting a wider range of urllib3 versions


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Resolves #290

Retry on HTTP status 412 for Server Side Consistent Token feature in Vault Enterprise.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
_connection_options

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See: 
- https://www.vaultproject.io/docs/faq/ssct#q-is-there-anything-else-i-need-to-consider-to-achieve-consistency-besides-upgrading-to-vault-1-10
- https://www.vaultproject.io/api-docs#412

Slightly related:
- #170 
