### PR TITLE
add the changelog to the collection docsite

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Once the new collection is published and the Zuul job is finished, add a release
 
 ## Release notes
 
-See the [changelog](https://github.com/ansible-collections/community.hashi_vault/tree/main/CHANGELOG.rst).
+See the [rendered changelog](https://ansible-collections.github.io/community.hashi_vault/branch/main/collections/community/hashi_vault/docsite/CHANGELOG.html) or the [raw generated changelog](https://github.com/ansible-collections/community.hashi_vault/tree/main/CHANGELOG.rst).
 
 ## FAQ
 

--- a/docs/docsite/extra-docs.yml
+++ b/docs/docsite/extra-docs.yml
@@ -1,5 +1,8 @@
 ---
 sections:
+  - title: Changelog
+    toctree:
+      - CHANGELOG
   - title: Guides
     toctree:
       - filter_guide

--- a/docs/docsite/rst/CHANGELOG.rst
+++ b/docs/docsite/rst/CHANGELOG.rst
@@ -1,0 +1,1 @@
+../../../CHANGELOG.rst


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Since the collection's changelog is already RST, I had the idea of adding it to the docsite, so folks could more easily see the collection's changelog specifically.

Rendered:
- https://ansible-collections.github.io/community.hashi_vault/pr/299/collections/community/hashi_vault/index.html

---

I want to get feedback from the community and [DaWGs](https://github.com/ansible/community/issues/643) about:
- whether this is a good idea
- if the way I'm implementing it makes sense
- if we maybe want to provide a better/easier path for this via changes to the docs generation process
- if I've missed something entirely and the changelog is actually published on the docsite (though I would argue if so, it's been hard to find, and doing it this way will make it visible in local doc generation too)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

