### PR TITLE
Docs/build update stuff

### DIFF
--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -38,7 +38,7 @@ jobs:
     if: github.repository == 'ansible-collections/community.hashi_vault'
     permissions:
       contents: read
-    needs: [build-docs]
+    needs: [validate-docs, build-docs]
     name: Publish Ansible Docs
     uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-publish-surge.yml@main
     with:
@@ -52,7 +52,7 @@ jobs:
     if: github.repository == 'ansible-collections/community.hashi_vault'
     permissions:
       contents: write
-    needs: [build-docs]
+    needs: [validate-docs, build-docs]
     name: Publish Ansible Docs
     uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-publish-gh-pages.yml@main
     with:

--- a/docs/preview/.gitignore
+++ b/docs/preview/.gitignore
@@ -1,3 +1,7 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 /temp-rst
 /build
 /rst/collections

--- a/docs/preview/antsibull-docs.cfg
+++ b/docs/preview/antsibull-docs.cfg
@@ -1,0 +1,22 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+breadcrumbs = true
+indexes = true
+use_html_blobs = false
+
+# You can specify ways to convert a collection name (<namespace>.<name>) to an URL here.
+# You can replace either of <namespace> or <name> by "*" to match all values in that place,
+# or use "*" for the collection name to match all collections. In the URL, you can use
+# {namespace} and {name} for the two components of the collection name. If you want to use
+# "{" or "}" in the URL, write "{{" or "}}" instead. Basically these are Python format
+# strings (https://docs.python.org/3.8/library/string.html#formatstrings).
+collection_url = {
+  * = "https://galaxy.ansible.com/{namespace}/{name}"
+}
+
+# The same wildcard rules and formatting rules as for collection_url apply.
+collection_install = {
+  * = "ansible-galaxy collection install {namespace}.{name}"
+}

--- a/docs/preview/build.sh
+++ b/docs/preview/build.sh
@@ -1,19 +1,25 @@
 #!/usr/bin/env bash
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 set -e
 pushd "${BASH_SOURCE%/*}"
 
 # Create collection documentation into temporary directory
 rm -rf temp-rst
 mkdir -p temp-rst
-antsibull-docs collection \
+antsibull-docs \
+    --config-file antsibull-docs.cfg \
+    collection \
     --use-current \
     --dest-dir temp-rst \
     community.hashi_vault
 
 # Copy collection documentation into source directory
-rsync -avc --delete-after temp-rst/collections/ rst/collections/
+rsync -cprv --delete-after temp-rst/collections/ rst/collections/
 
 # Build Sphinx site
-sphinx-build -M html rst build -c .
+sphinx-build -M html rst build -c . -W --keep-going
 
 popd

--- a/docs/preview/conf.py
+++ b/docs/preview/conf.py
@@ -1,3 +1,7 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 # This file only contains a selection of the most common options. For a full list see the
 # documentation:
 # http://www.sphinx-doc.org/en/master/config

--- a/docs/preview/requirements.txt
+++ b/docs/preview/requirements.txt
@@ -1,4 +1,8 @@
-antsibull-docs
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+antsibull-docs >= 1.0.0, < 2.0.0
 ansible-pygments
 sphinx
-sphinx-ansible-theme
+sphinx-ansible-theme >= 0.9.0

--- a/docs/preview/requirements.txt
+++ b/docs/preview/requirements.txt
@@ -4,5 +4,5 @@
 
 antsibull-docs >= 1.0.0, < 2.0.0
 ansible-pygments
-sphinx
+sphinx != 5.2.0.post0  # temporary, see https://github.com/ansible-community/antsibull-docs/issues/39, https://github.com/ansible-community/antsibull-docs/issues/40
 sphinx-ansible-theme >= 0.9.0

--- a/docs/preview/rst/index.rst
+++ b/docs/preview/rst/index.rst
@@ -1,9 +1,13 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 .. _docsite_root_index:
 
 Ansible collection documentation preview
 ========================================
 
-This docsite contains documentation from ``community.hashi_vault``.
+This docsite contains documentation for ``community.hashi_vault``.
 
 
 .. toctree::


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Some stuff taken from #260 

- update the workflow dependency
- update the preview stuff (committed `antsibull-docs sphinx-init` output)
- exclude sphinx `.post0` release due to https://github.com/ansible-community/antsibull-docs/issues/39

Merging will fix the currently broken docs build; it will fail in this PR in the "base" build due this not being in `main` yet.
Validate ~should pass~ will not pass because with the change to use `2.14` for docs builds, the missing filter documentation is now a fatal error.

~I'm going to merge these changes first so that the base docs build in #260 can pass.~

Actually.. the base build will still fail because of the missing filter docs I suppose.. oof. Am going to just close this and do everything in the other one I guess.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

