### PR TITLE
`vault_kv2_get` lookup - change `engine_mount_point` default to `secret`

### DIFF
--- a/changelogs/fragments/279-vault_kv2_get-lookup-mount-default.yml
+++ b/changelogs/fragments/279-vault_kv2_get-lookup-mount-default.yml
@@ -1,0 +1,3 @@
+---
+breaking_changes:
+  - vault_kv2_get lookup - as previously announced, the default value for ``engine_mount_point`` in the ``vault_kv2_get`` lookup has changed from ``kv`` to ``secret`` (https://github.com/ansible-collections/community.hashi_vault/issues/279).

--- a/plugins/lookup/vault_kv2_get.py
+++ b/plugins/lookup/vault_kv2_get.py
@@ -41,10 +41,7 @@ options:
     type: str
     required: True
   engine_mount_point:
-    description:
-      - The path where the secret backend is mounted.
-      - The default value is C(kv).
-      - The default value will change to C(secret) in version 4.0.0 to match the module's default.
+    default: secret
   version:
     description: Specifies the version to return. If not set the latest version is returned.
     type: int
@@ -55,7 +52,7 @@ EXAMPLES = r'''
   ansible.builtin.set_fact:
     response: "{{ lookup('community.hashi_vault.vault_kv2_get', 'hello', url='https://vault:8201') }}"
   # equivalent API path in 3.x.x is kv/data/hello
-  # equivalent API path in 4.0.0+ will be secret/data/hello
+  # equivalent API path in 4.0.0+ is secret/data/hello
 
 - name: Display the results
   ansible.builtin.debug:
@@ -208,14 +205,7 @@ class LookupModule(HashiVaultLookupBase):
         client = self.helper.get_vault_client(**client_args)
 
         version = self._options_adapter.get_option_default('version')
-        engine_mount_point = self._options_adapter.get_option_default('engine_mount_point')
-        if engine_mount_point is None:
-            engine_mount_point = 'kv'
-            display.deprecated(
-                "The default value for 'engine_mount_point' will change from 'kv' to 'secret'.",
-                version='4.0.0',
-                collection_name='community.hashi_vault'
-            )
+        engine_mount_point = self._options_adapter.get_option('engine_mount_point')
 
         try:
             self.authenticator.validate()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #279 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vault_kv2_get lookup
