### PR TITLE
update proxy tests for urllib>=2

### DIFF
--- a/tests/integration/targets/connection_options/tasks/controller.yml
+++ b/tests/integration/targets/connection_options/tasks/controller.yml
@@ -44,7 +44,7 @@
         - assert:
             that:
               - result is failed
-              - result.msg is search('Cannot connect to proxy')
+              - result.msg is search('(?:Cannot|Unable to) connect to proxy')
               - result.retries == 2
 
     - name: HTTPS connection
@@ -93,5 +93,5 @@
         - assert:
             that:
               - result is failed
-              - result.msg is search('Cannot connect to proxy')
+              - result.msg is search('(?:Cannot|Unable to) connect to proxy')
               - result.retries == 2

--- a/tests/integration/targets/connection_options/tasks/target.yml
+++ b/tests/integration/targets/connection_options/tasks/target.yml
@@ -37,7 +37,7 @@
         - assert:
             that:
               - result.inner is failed
-              - result.msg is search('Cannot connect to proxy')
+              - result.msg is search('(?:Cannot|Unable to) connect to proxy')
               - result.retries == 2
 
     - name: HTTPS connection
@@ -80,5 +80,5 @@
         - assert:
             that:
               - result.inner is failed
-              - result.msg is search('Cannot connect to proxy')
+              - result.msg is search('(?:Cannot|Unable to) connect to proxy')
               - result.retries == 2


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Tests have been failing because some combinations of controller and python versions end up installing `urllib>=2` where the proxy connection error message changed slightly. 

This is not a bug since it shouldn't have affected actual functionality, it's just the tests that were looking for a specific message.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Tests Pull Request
