### PR TITLE
Replace fstring in unit tests to allow testing in older versions of python

### DIFF
--- a/tests/unit/plugins/plugin_utils/base/test_hashi_vault_lookup_base.py
+++ b/tests/unit/plugins/plugin_utils/base/test_hashi_vault_lookup_base.py
@@ -83,6 +83,7 @@ class TestHashiVaultLookupBase(object):
         expected_template = "Duplicate key '%s' in the term string '%s'."
         expected_msg = expected_template % (dup_key, term)
         expected_re = re_escape(expected_msg)
+        expected_match = "^%s$" % (expected_re,)
 
-        with pytest.raises(AnsibleOptionsError, match=f"^{expected_re}$"):
+        with pytest.raises(AnsibleOptionsError, match=expected_match):
             hashi_vault_lookup_module.parse_kev_term(term, plugin_name='fake', first_unqualified=dup_key)


### PR DESCRIPTION
##### SUMMARY
Older versions of python do not support the use of fstrings. This change replaces fstring references with a substitution.

##### ISSUE TYPE
- Tests Pull Request