### PR TITLE
Ci/docker compose pyyaml cython -- unit mock assertions

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -362,6 +362,7 @@ jobs:
       - name: localenv_docker - setup
         run: |
           pwd
+          pip install --upgrade pip setuptools build wheel
           pip install "Cython<3.0" "pyyaml<6" --no-build-isolation
           # ^ https://github.com/yaml/pyyaml/issues/601
           # ^ https://github.com/docker/compose/issues/10836

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -362,6 +362,9 @@ jobs:
       - name: localenv_docker - setup
         run: |
           pwd
+          pip install "Cython<3.0" "pyyaml<6" --no-build-isolation
+          # ^ https://github.com/yaml/pyyaml/issues/601
+          # ^ https://github.com/docker/compose/issues/10836
           pip install -r files/requirements/requirements.txt -c files/requirements/constraints.txt
           ./setup.sh
         working-directory: ${{ env.COLLECTION_INTEGRATION_TARGETS }}/setup_localenv_docker

--- a/tests/integration/targets/setup_localenv_docker/files/requirements/constraints.txt
+++ b/tests/integration/targets/setup_localenv_docker/files/requirements/constraints.txt
@@ -1,2 +1,1 @@
 docker >= 5.0.0 ; python_version >= '3.6'
-docker < 5.0.0 ; python_version == '2.7'

--- a/tests/integration/targets/setup_localenv_docker/files/requirements/requirements.txt
+++ b/tests/integration/targets/setup_localenv_docker/files/requirements/requirements.txt
@@ -1,3 +1,2 @@
 docker
 docker-compose
-six  # https://github.com/ansible-collections/community.docker/issues/171

--- a/tests/unit/plugins/module_utils/authentication/test_auth_aws_iam.py
+++ b/tests/unit/plugins/module_utils/authentication/test_auth_aws_iam.py
@@ -163,7 +163,7 @@ class TestAuthAwsIam(object):
 
         params = auth_aws_iam._auth_aws_iam_login_params
 
-        assert boto3.session.Session.called_once_with(profile_name=profile)
+        boto3.session.Session.assert_called_once_with(profile_name=profile)
 
         assert params['access_key'] == aws_access_key
         assert params['secret_key'] == aws_secret_key

--- a/tests/unit/plugins/module_utils/authentication/test_auth_azure.py
+++ b/tests/unit/plugins/module_utils/authentication/test_auth_azure.py
@@ -157,10 +157,10 @@ class TestAuthAzure(object):
             credential.get_token.return_value.token = jwt
             auth_azure.validate()
 
-            assert mocked_credential_class.called_once_with(
+            mocked_credential_class.assert_called_once_with(
                 azure_tenant_id, azure_client_id, azure_client_secret
             )
-            assert credential.get_token.called_once_with(
+            credential.get_token.assert_called_once_with(
                 'https://management.azure.com//.default'
             )
 
@@ -194,8 +194,8 @@ class TestAuthAzure(object):
             credential.get_token.return_value.token = jwt
             auth_azure.validate()
 
-            assert mocked_credential_class.called_once_with(azure_client_id)
-            assert credential.get_token.called_once_with(
+            mocked_credential_class.assert_called_once_with(azure_client_id)
+            credential.get_token.assert_called_once_with(
                 'https://management.azure.com//.default'
             )
 
@@ -215,8 +215,8 @@ class TestAuthAzure(object):
             credential.get_token.return_value.token = jwt
             auth_azure.validate()
 
-            assert mocked_credential_class.called_once_with()
-            assert credential.get_token.called_once_with(
+            mocked_credential_class.assert_called_once_with()
+            credential.get_token.assert_called_once_with(
                 'https://management.azure.com//.default'
             )
 

--- a/tests/unit/plugins/module_utils/authentication/test_auth_azure.py
+++ b/tests/unit/plugins/module_utils/authentication/test_auth_azure.py
@@ -194,7 +194,7 @@ class TestAuthAzure(object):
             credential.get_token.return_value.token = jwt
             auth_azure.validate()
 
-            mocked_credential_class.assert_called_once_with(azure_client_id)
+            mocked_credential_class.assert_called_once_with(client_id=azure_client_id)
             credential.get_token.assert_called_once_with(
                 'https://management.azure.com//.default'
             )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
CI is failing recently on local integration testing due to some dependency issues. 
`docker-compose` depends on `pyyaml<6` whose installation is broken with the newly released `cython==3`.

- https://github.com/docker/compose/issues/10836
- https://github.com/yaml/pyyaml/issues/601

Until someone fixes things in a way that doesn't require a workaround, we're putting a workaround in place.

Also took this opportunity to remove `six` and a constraint for py2.7 since we don't support it anymore.

---

Another error has been revealed: we had several instances of `assert some_mock.called_once_with(...)` which is a classic error; the method name is `assert_called_once_with` and since the mock returns a `MagicMock` for all members that don't exist, the incorrect form always asserts `True`.

It seems that in python 3.12 this case has been caught as a probable error, and our CI is failing on these:
- https://github.com/python/cpython/issues/100690


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- CI Pull Request
- Tests Pull Request
