### PR TITLE
v6 changes: split Vault testing, drop core 2.13, add py3.12, bump hvac minimum, add dependabot, more small changes

### DIFF
--- a/.github/actions/docker-image-versions/action.yml
+++ b/.github/actions/docker-image-versions/action.yml
@@ -8,8 +8,7 @@ outputs:
 inputs:
   image:
     description: The docker image name.
-    required: false
-    default: vault
+    required: true
   num_major_versions:
     description: Number of unique major versions to return.
     required: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+---
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ansible-builder.yml
+++ b/.github/workflows/ansible-builder.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
 
       - name: Install ansible-builder
         run: pip install ansible-builder

--- a/.github/workflows/ansible-builder.yml
+++ b/.github/workflows/ansible-builder.yml
@@ -24,8 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
+          show-progress: false
           path: ansible_collections/${{ env.NAMESPACE }}/${{ env.COLLECTION_NAME }}
 
       - name: Set up Python

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -226,6 +226,8 @@ jobs:
           - ansible: 'stable-2.15'
             python: '3.7'
           - ansible: 'stable-2.15'
+            python: '3.12'
+          - ansible: 'stable-2.15'
             python: '3.8'
           - ansible: 'stable-2.14'
             python: '3.12'

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -180,7 +180,7 @@ jobs:
 
   integration:
     runs-on: ${{ matrix.runner }}
-    name: I (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }})
+    name: I (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }}+V[-${{ matrix.vault_minus }}])
     strategy:
       fail-fast: false
       matrix:
@@ -188,6 +188,9 @@ jobs:
           - ubuntu-latest
         test_container:
           - default
+        vault_minus:
+          - 0
+          - 1
         ansible:
           - stable-2.13
           - stable-2.14
@@ -256,6 +259,7 @@ jobs:
         id: vault_versions
         uses: ./.github/actions/docker-image-versions
         with:
+          image: hashicorp/vault
           num_major_versions: 1
           num_minor_versions: 2
           num_micro_versions: 1
@@ -271,23 +275,10 @@ jobs:
           working-directory: ${{ env.COLLECTION_PATH }}
           ansible-test-invocation: ${{ env.TEST_INVOCATION }}
 
-      - name: Set Vault Version (older)
+      - name: Set Vault Version
         uses: briantist/ezenv@v1
         with:
           env: VAULT_VERSION=${{ fromJSON(steps.vault_versions.outputs.versions)[1] }}
-
-      - name: Prepare docker dependencies (Vault ${{ env.VAULT_VERSION }})
-        run: ./setup.sh -e vault_version=${VAULT_VERSION}
-        working-directory: ${{ env.COLLECTION_INTEGRATION_TARGETS }}/setup_localenv_gha
-
-      - name: Run integration test (Vault ${{ env.VAULT_VERSION }})
-        run: ansible-test ${{ env.TEST_INVOCATION }}
-        working-directory: ${{ env.COLLECTION_PATH }}
-
-      - name: Set Vault Version (newer)
-        uses: briantist/ezenv@v1
-        with:
-          env: VAULT_VERSION=${{ fromJSON(steps.vault_versions.outputs.versions)[0] }}
 
       - name: Prepare docker dependencies (Vault ${{ env.VAULT_VERSION }})
         run: ./setup.sh -e vault_version=${VAULT_VERSION}

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -68,7 +68,7 @@ jobs:
           python-version: '3.11'
 
       # Install the head of the given branch (devel, stable-2.14)
-      - name: Install ansible-base (${{ matrix.ansible }})
+      - name: Install ansible-core (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
 
       - name: Pull Ansible test images
@@ -141,7 +141,7 @@ jobs:
           # will run on all python versions it supports.
           python-version: '3.11'
 
-      - name: Install ansible-base (${{ matrix.ansible }})
+      - name: Install ansible-core (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
 
       - name: Pull Ansible test images
@@ -264,7 +264,7 @@ jobs:
           num_minor_versions: 2
           num_micro_versions: 1
 
-      - name: Install ansible-base (${{ matrix.ansible }})
+      - name: Install ansible-core (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
 
       - name: Pull Ansible test images
@@ -342,7 +342,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      - name: Install ansible-base (${{ matrix.ansible }})
+      - name: Install ansible-core (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
 
       - name: Install community.crypto

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -307,8 +307,7 @@ jobs:
           retention-days: 1
 
   local_test_invocation:
-    # runs-on: ${{ matrix.runner }}
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ${{ matrix.runner }}
     name: LI - ${{ matrix.runner }} (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }})
     strategy:
       fail-fast: false

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -278,7 +278,7 @@ jobs:
       - name: Set Vault Version
         uses: briantist/ezenv@v1
         with:
-          env: VAULT_VERSION=${{ fromJSON(steps.vault_versions.outputs.versions)[1] }}
+          env: VAULT_VERSION=${{ fromJSON(steps.vault_versions.outputs.versions)[matrix.vault_minus] }}
 
       - name: Prepare docker dependencies (Vault ${{ env.VAULT_VERSION }})
         run: ./setup.sh -e vault_version=${VAULT_VERSION}

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -53,8 +53,9 @@ jobs:
             TEST_INVOCATION="sanity --docker ${{ matrix.test_container }} -v --color ${{ github.event_name != 'schedule' && '--coverage' || '' }}"
 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
+          show-progress: false
           path: ${{ env.COLLECTION_PATH }}
 
       - name: Link to .github  # easier access to local actions
@@ -127,8 +128,9 @@ jobs:
             TEST_INVOCATION="units --color --docker ${{ matrix.test_container }} ${{ github.event_name != 'schedule' && '--coverage' || '' }}"
 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
+          show-progress: false
           path: ${{ env.COLLECTION_PATH }}
 
       - name: Link to .github  # easier access to local actions
@@ -243,8 +245,9 @@ jobs:
             TEST_INVOCATION="integration -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --docker ${{ matrix.test_container }} ${{ github.event_name != 'schedule' && '--coverage' || '' }} --docker-network hashi_vault_default"
 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
+          show-progress: false
           path: ${{ env.COLLECTION_PATH }}
 
       - name: Link to .github  # easier access to local actions
@@ -330,8 +333,9 @@ jobs:
             DOCKER_TEST_INVOCATION="integration -v --color --retry-on-error --continue-on-error --controller docker:${{ matrix.test_container }},python=${{ matrix.python }} ${{ github.event_name != 'schedule' && '--coverage' || '' }}"
 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
+          show-progress: false
           path: ${{ env.COLLECTION_PATH }}
 
       - name: Link to .github  # easier access to local actions
@@ -426,7 +430,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Download artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -37,7 +37,6 @@ jobs:
         test_container:
           - default
         ansible:
-          - stable-2.13
           - stable-2.14
           - stable-2.15
           - stable-2.16
@@ -66,7 +65,7 @@ jobs:
         with:
           # it is just required to run that once as "ansible-test sanity" in the docker image
           # will run on all python versions it supports.
-          python-version: '3.10'
+          python-version: '3.11'
 
       # Install the head of the given branch (devel, stable-2.14)
       - name: Install ansible-base (${{ matrix.ansible }})
@@ -114,7 +113,6 @@ jobs:
         test_container:
           - default
         ansible:
-          - stable-2.13
           - stable-2.14
           - stable-2.15
           - stable-2.16
@@ -141,7 +139,7 @@ jobs:
         with:
           # it is just required to run that once as "ansible-test units" in the docker image
           # will run on all python versions it supports.
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install ansible-base (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
@@ -192,7 +190,6 @@ jobs:
           - 0
           - 1
         ansible:
-          - stable-2.13
           - stable-2.14
           - stable-2.15
           - stable-2.16
@@ -204,11 +201,18 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
         exclude:
           # https://docs.ansible.com/ansible/devel/installation_guide/intro_installation.html#control-node-requirements
           # https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
-          - ansible: 'stable-2.13'
-            python: '3.11'
+          - ansible: 'devel'
+            python: '3.6'
+          - ansible: 'devel'
+            python: '3.7'
+          - ansible: 'devel'
+            python: '3.8'
+          - ansible: 'devel'
+            python: '3.9'
           - ansible: 'stable-2.16'
             python: '3.6'
           - ansible: 'stable-2.16'
@@ -223,14 +227,8 @@ jobs:
             python: '3.7'
           - ansible: 'stable-2.15'
             python: '3.8'
-          - ansible: 'devel'
-            python: '3.6'
-          - ansible: 'devel'
-            python: '3.7'
-          - ansible: 'devel'
-            python: '3.8'
-          - ansible: 'devel'
-            python: '3.9'
+          - ansible: 'stable-2.14'
+            python: '3.12'
 
     steps:
       - name: Initialize env vars
@@ -253,7 +251,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Get Vault versions
         id: vault_versions
@@ -313,7 +311,7 @@ jobs:
           - stable-2.16
           - devel
         python:
-          - '3.11'
+          - '3.12'
         runner:
           - ubuntu-latest
         test_container:

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -307,7 +307,8 @@ jobs:
           retention-days: 1
 
   local_test_invocation:
-    runs-on: ${{ matrix.runner }}
+    # runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-latest-4-cores
     name: LI - ${{ matrix.runner }} (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }})
     strategy:
       fail-fast: false

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.12
 
       - name: Install PyYaml
         run: pip install pyyaml

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -15,7 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -25,10 +25,10 @@ jobs:
           python-version: 3.12
 
       - name: Install PyYaml
-        run: pip install pyyaml
+        run: pip install pyyaml ansible-core
 
       - name: Validate version is published to Galaxy
-        run: curl --head -s -f -o /dev/null https://galaxy.ansible.com/download/community-hashi_vault-${{ github.event.inputs.version }}.tar.gz
+        run: ansible-galaxy collection download -vvv -p /tmp 'community.hashi_vault:==${{ github.event.inputs.version }}''
 
       - name: Build release description
         shell: python

--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ Browsing the [**devel** collection documentation](https://docs.ansible.com/ansib
 We also separately publish [**latest commit** collection documentation](https://ansible-collections.github.io/community.hashi_vault/branch/main/) which shows docs for the _latest commit in the `main` branch_.
 
 If you use the Ansible package and don't update collections independently, use **latest**, if you install or update this collection directly from Galaxy, use **devel**. If you are looking to contribute, use **latest commit**.
+
 ## Tested with Ansible
 
-* 2.13
-* 2.14
-* 2.15
-* 2.16
-* devel (latest development commit)
+Please refer to the [`ansible-core` support matrix](https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix) to see which versions of `ansible-core` are still supported or end-of-life.
+
+Generally, we release a new major version of this collection a little before the release of a new `ansible-core` version, which is around every 6 months. In that release, we will update the CI matrix to drop the core versions that are about to go EoL, and add in new core versions if they have not been added already.
+
+We also regularly test against the [`devel` branch](https://github.com/ansible/ansible/tree/devel) (latest development commit).
 
 See [the CI configuration](https://github.com/ansible-collections/community.hashi_vault/blob/main/.github/workflows/ansible-test.yml) for the most accurate testing information.
-<!-- List the versions of Ansible the collection has been tested with. Must match what is in galaxy.yml. -->
 
 ## Tested with Vault
 
@@ -46,6 +46,7 @@ Currently we support and test against Python versions:
 * 3.9
 * 3.10
 * 3.11
+* 3.12
 
 Note that for controller-side plugins, only the Python versions supported by the Ansible controller are supported (for example, you cannot use Python 3.7 with Ansible core 2.12).
 

--- a/changelogs/fragments/403-core-vault-python.yml
+++ b/changelogs/fragments/403-core-vault-python.yml
@@ -1,0 +1,6 @@
+---
+removed_features:
+  - The minimum supported version of ``ansible-core`` is now ``2.14``, support for ``2.13`` has been dropped (https://github.com/ansible-collections/community.hashi_vault/pull/403).
+
+trivial:
+  - The ``docker-image-versions`` action in the collection has been updated to support dockerhub images that are not in the default namespace. The ``image`` input is now required and no longer defaults to ``vault`` which is no longer the current location of Vault images (https://github.com/ansible-collections/community.hashi_vault/pull/403).

--- a/changelogs/fragments/403-core-vault-python.yml
+++ b/changelogs/fragments/403-core-vault-python.yml
@@ -3,7 +3,7 @@ removed_features:
   - The minimum supported version of ``ansible-core`` is now ``2.14``, support for ``2.13`` has been dropped (https://github.com/ansible-collections/community.hashi_vault/pull/403).
 
 trivial:
-  - The ``docker-image-versions`` action in the collection has been updated to support dockerhub images that are not in the default namespace. The ``image`` input is now required and no longer defaults to ``vault`` which is no longer the current location of Vault images (https://github.com/ansible-collections/community.hashi_vault/pull/403).
+  - The ``docker-image-versions`` action in the collection has been updated to support Docker Hub images that are not in the default namespace. The ``image`` input is now required and no longer defaults to ``vault`` which is no longer the current location of Vault images (https://github.com/ansible-collections/community.hashi_vault/pull/403).
 
-major_changes:
+breaking_changes:
   - The minimum required version of ``hvac`` is now ``1.2.1`` (https://docs.ansible.com/ansible/devel/collections/community/hashi_vault/docsite/user_guide.html#hvac-version-specifics).

--- a/changelogs/fragments/403-core-vault-python.yml
+++ b/changelogs/fragments/403-core-vault-python.yml
@@ -4,3 +4,6 @@ removed_features:
 
 trivial:
   - The ``docker-image-versions`` action in the collection has been updated to support dockerhub images that are not in the default namespace. The ``image`` input is now required and no longer defaults to ``vault`` which is no longer the current location of Vault images (https://github.com/ansible-collections/community.hashi_vault/pull/403).
+
+major_changes:
+  - The minimum required version of ``hvac`` is now ``1.2.1`` (https://docs.ansible.com/ansible/devel/collections/community/hashi_vault/docsite/user_guide.html#hvac-version-specifics).

--- a/docs/docsite/rst/user_guide.rst
+++ b/docs/docsite/rst/user_guide.rst
@@ -33,7 +33,7 @@ In general, we recommend using the latest version of ``hvac`` that is supported 
 
 As of ``community.hashi_vault`` version ``5.0.0`` we are setting a minimum supported version of ``hvac``.
 
-**The current required minimum ``hvac`` version is ``1.1.0``.**
+**The current required minimum** ``hvac`` **version is** ``1.2.1``.
 
 Other requirements
 ------------------

--- a/meta/ee-requirements.txt
+++ b/meta/ee-requirements.txt
@@ -1,6 +1,6 @@
 # ansible-builder doesn't seem to properly handle "; python_version" type of constraints
 # requirements here are assuming python 3.6 or higher
-hvac >=0.10.6
+hvac >= 1.2.1
 urllib3 >= 1.15
 
 boto3       # these are only needed if inferring AWS credentials or

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.13.0'
+requires_ansible: '>=2.14.0'
 action_groups:
   # let's keep this in alphabetical order
   vault:

--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -52,7 +52,7 @@ typed-ast == 1.4.0  # 1.4.0 is required to compile on Python 3.8
 wrapt == 1.11.1
 
 # hvac
-hvac >= 1.1.0 ; python_version >= '3.6'
+hvac >= 1.2.1 ; python_version >= '3.6'
 
 # urllib3
 # these should be satisfied naturally by the requests versions required by hvac anyway


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Split integration matrix for Vault versions now that we have more concurrency in GHA
- Use the correct Vault docker image in integration tests
- Drop support for core 2.13
- Add support for Python 3.12
- Bump minimum `hvac` version to `1.2.1`
- Fix formatting in user guide requirements
- Bump actions/checkout to v4 and disable git progress
- Update release workflow to support galaxy v3
- Update readme
- Add dependabot.yml
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- CI Pull Request
