### PR TITLE
`vault_write` fix ability to use `data` and `write_ttl` keys

### DIFF
--- a/changelogs/fragments/404-vault_write-spicy-keys.yml
+++ b/changelogs/fragments/404-vault_write-spicy-keys.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - vault_write - the ``vault_write`` lookup and module were not able to write data containing keys named ``path`` or ``wrap_ttl`` due to a bug in the ``hvac`` library. These plugins have now been updated to take advantage of fixes in ``hvac>=1.2`` to address this (https://github.com/ansible-collections/community.hashi_vault/issues/389).

--- a/plugins/lookup/vault_write.py
+++ b/plugins/lookup/vault_write.py
@@ -43,7 +43,9 @@ DOCUMENTATION = """
       type: str
       required: true
     data:
-      description: A dictionary to be serialized to JSON and then sent as the request body.
+      description:
+        - A dictionary to be serialized to JSON and then sent as the request body.
+        - If the dictionary contains keys named C(path) or C(wrap_ttl), the call will fail with C(hvac<1.2).
       type: dict
       required: false
       default: {}

--- a/plugins/lookup/vault_write.py
+++ b/plugins/lookup/vault_write.py
@@ -122,8 +122,8 @@ from ansible.utils.display import Display
 
 from ansible.module_utils.six import raise_from
 
-from ansible_collections.community.hashi_vault.plugins.plugin_utils._hashi_vault_lookup_base import HashiVaultLookupBase
-from ansible_collections.community.hashi_vault.plugins.module_utils._hashi_vault_common import HashiVaultValueError
+from ..plugin_utils._hashi_vault_lookup_base import HashiVaultLookupBase
+from ..module_utils._hashi_vault_common import HashiVaultValueError
 
 display = Display()
 

--- a/plugins/modules/vault_write.py
+++ b/plugins/modules/vault_write.py
@@ -108,8 +108,8 @@ import traceback
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import missing_required_lib
 
-from ansible_collections.community.hashi_vault.plugins.module_utils._hashi_vault_module import HashiVaultModule
-from ansible_collections.community.hashi_vault.plugins.module_utils._hashi_vault_common import HashiVaultValueError
+from ..module_utils._hashi_vault_module import HashiVaultModule
+from ..module_utils._hashi_vault_common import HashiVaultValueError
 
 try:
     import hvac

--- a/plugins/modules/vault_write.py
+++ b/plugins/modules/vault_write.py
@@ -46,7 +46,9 @@ DOCUMENTATION = """
       type: str
       required: True
     data:
-      description: A dictionary to be serialized to JSON and then sent as the request body.
+      description:
+        - A dictionary to be serialized to JSON and then sent as the request body.
+        - If the dictionary contains keys named C(path) or C(wrap_ttl), the call will fail with C(hvac<1.2).
       type: dict
       required: false
       default: {}

--- a/tests/integration/targets/lookup_vault_write/tasks/lookup_vault_write_test.yml
+++ b/tests/integration/targets/lookup_vault_write/tasks/lookup_vault_write_test.yml
@@ -11,6 +11,9 @@
     test_data:
       a: 1
       b: two
+      # https://github.com/ansible-collections/community.hashi_vault/issues/389
+      path: path_value
+      wrap_ttl: wrap_ttl_value
   block:
     - name: Write data to the cubbyhole
       vars:

--- a/tests/integration/targets/module_vault_write/tasks/module_vault_write_test.yml
+++ b/tests/integration/targets/module_vault_write/tasks/module_vault_write_test.yml
@@ -20,6 +20,9 @@
         data:
           a: 1
           b: two
+          # https://github.com/ansible-collections/community.hashi_vault/issues/389
+          path: path_value
+          wrap_ttl: wrap_ttl_value
 
     - assert:
         that:
@@ -42,6 +45,9 @@
         data:
           a: 1
           b: two
+          # https://github.com/ansible-collections/community.hashi_vault/issues/389
+          path: path_value
+          wrap_ttl: wrap_ttl_value
 
     - assert:
         that:
@@ -57,7 +63,13 @@
         that:
           - "'result' in result"
           - "'data' in result.result"
-          - "result.result.data == {'a': 1, 'b': 'two'}"
+          - >
+            result.result.data == {
+              'a': 1,
+              'b': 'two',
+              'path': 'path_value',
+              'wrap_ttl': 'wrap_ttl_value',
+            }
 
     - name: Write data to an endpoint that returns data and test wrapping
       register: result

--- a/tests/unit/plugins/lookup/test_vault_write.py
+++ b/tests/unit/plugins/lookup/test_vault_write.py
@@ -70,7 +70,7 @@ class TestVaultWriteLookup(object):
 
         expected_calls = [mock.call(path=p, wrap_ttl=wrap_ttl, data=data) for p in paths]
 
-        def _fake_write(path, wrap_ttl, data={}):
+        def _fake_write(path, wrap_ttl, data=None):
             r = approle_secret_id_write_response.copy()
             r.update({'path': path})
             return r

--- a/tests/unit/plugins/modules/test_vault_write.py
+++ b/tests/unit/plugins/modules/test_vault_write.py
@@ -88,7 +88,7 @@ class TestModuleVaultWrite():
     @pytest.mark.parametrize('patch_ansible_module', [[_combined_options(), 'data', 'wrap_ttl']], indirect=True)
     def test_vault_write_return_data(self, patch_ansible_module, approle_secret_id_write_response, vault_client, opt_wrap_ttl, opt_data, capfd):
         client = vault_client
-        client.write.return_value = approle_secret_id_write_response
+        client.write_data.return_value = approle_secret_id_write_response
 
         with pytest.raises(SystemExit) as e:
             vault_write.main()
@@ -98,7 +98,7 @@ class TestModuleVaultWrite():
 
         assert e.value.code == 0, "result: %r" % (result,)
 
-        client.write.assert_called_once_with(path=patch_ansible_module['path'], wrap_ttl=opt_wrap_ttl, **opt_data)
+        client.write_data.assert_called_once_with(path=patch_ansible_module['path'], wrap_ttl=opt_wrap_ttl, data=opt_data)
 
         assert result['data'] == approle_secret_id_write_response, (
             "module result did not match expected result:\nmodule: %r\nexpected: %r" % (result['data'], approle_secret_id_write_response)
@@ -110,7 +110,7 @@ class TestModuleVaultWrite():
 
         requests_unparseable_response.status_code = 204
 
-        client.write.return_value = requests_unparseable_response
+        client.write_data.return_value = requests_unparseable_response
 
         with pytest.raises(SystemExit) as e:
             vault_write.main()
@@ -129,7 +129,7 @@ class TestModuleVaultWrite():
         requests_unparseable_response.status_code = 200
         requests_unparseable_response.content = '﷽'
 
-        client.write.return_value = requests_unparseable_response
+        client.write_data.return_value = requests_unparseable_response
 
         with pytest.raises(SystemExit) as e:
             vault_write.main()
@@ -166,7 +166,7 @@ class TestModuleVaultWrite():
     def test_vault_write_vault_exception(self, vault_client, exc, capfd):
 
         client = vault_client
-        client.write.side_effect = exc[0]
+        client.write_data.side_effect = exc[0]
 
         with pytest.raises(SystemExit) as e:
             vault_write.main()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #389 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vault_write

