### PR TITLE
ignore pushes on dependabot branches

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -2,6 +2,8 @@ name: CI
 on:
   # Run CI against all pushes (direct commits, also merged PRs), Pull Requests
   push:
+    branches-ignore:
+      - 'dependabot/**'
     paths-ignore:
       - 'docs/**'
       - '.github/workflows/_shared-*'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When dependabot opens a PR or updates its PR branch, it triggers CI for both the push and the PR, since the branch is local to repository.
This PR tries to ignore those branch pushes so only the PR trigger goes off.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- CI Pull Request
