### PR TITLE
make local integration faster

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -317,12 +317,20 @@ jobs:
         ansible:
           - stable-2.16
           - devel
+        delete_canaries:
+          - true
+          - false
         python:
           - '3.12'
         runner:
           - ubuntu-latest
         test_container:
           - default
+        exclude:
+          - ansible: devel
+            delete_canaries: false
+          - ansible: stable-2.16
+            delete_canaries: true
 
     steps:
       - name: Initialize env vars
@@ -385,13 +393,9 @@ jobs:
           ansible-test ${{ env.DOCKER_TEST_INVOCATION }} --docker-network hashi_vault_default
         working-directory: ${{ env.COLLECTION_PATH }}
 
-      - name: Run integration again (ensure tests do not break against still-running containers)
-        run: |
-          ansible-test ${{ env.DOCKER_TEST_INVOCATION }} --docker-network hashi_vault_default
-        working-directory: ${{ env.COLLECTION_PATH }}
-
       #TODO add capability in the Ansible side once vault_list and vault_delete exist
-      - name: Run a third time, but delete Vault's cubbyhole contents first
+      - name: Delete Vault's cubbyhole contents (ensure test setup is idempotent)
+        if: matrix.delete_canaries
         working-directory: ${{ env.COLLECTION_PATH }}
         env:
           VAULT_TOKEN: 47542cbc-6bf8-4fba-8eda-02e0a0d29a0a
@@ -402,6 +406,9 @@ jobs:
           | xargs -I{} -n 1 vault delete cubbyhole/{}' \
           | docker run --rm --network hashi_vault_default -e VAULT_TOKEN -e VAULT_ADDR -i hashicorp/vault sh
 
+      - name: Run integration again (ensure tests do not break against still-running containers)
+        working-directory: ${{ env.COLLECTION_PATH }}
+        run: |
           ansible-test ${{ env.DOCKER_TEST_INVOCATION }} --docker-network hashi_vault_default
 
         # ansible-test support producing code coverage data


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The local integration runs are the longest in the CI, since they run the full integration suite 3 times.
The idea is to ensure that integration tests still work properly in multiple runs against the same running Vault containers. Many of the integration tests have setup/teardown code that by our convention, must be idempotent. Many of them also use an optimization whereby they write a canary value to a cubbyhole, and if that value exists, the setup code is skipped, which saves a little bit of time.

So in CI, we run a normal "first run", a second run against the same containers (should skip setup code where canary values are found), and then a third run where we delete the cubbyhole canary values to ensure that the setup code is actually idempotent regardless of the canary values.

We run the LI tests against `devel` and the latest stable version of core, so we have two of these runs.

This PR attempts to let us optimize this process a little: one of the core versions will test with canary deletion, and the other won't, so each of those jobs will run the full integration suite twice instead of thrice, and we still cover both scenarios.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- CI Pull Request
