### PR TITLE
Adding variables for cert_auth_public and private params

### DIFF
--- a/changelogs/fragments/429-add-cert-auth-variables.yml
+++ b/changelogs/fragments/429-add-cert-auth-variables.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - Add option to set the cert_auth_public_key and cert_auth_private_key parameters using the variables ansible_hashi_vault_cert_auth_public_key and ansible_hashi_vault_cert_auth_private_key (https://github.com/ansible-collections/community.hashi_vault/pull/429).
+  - Add option to set the cert_auth_public_key and cert_auth_private_key parameters using the variables ansible_hashi_vault_cert_auth_public_key and ansible_hashi_vault_cert_auth_private_key (https://github.com/ansible-collections/community.hashi_vault/issues/428).

--- a/changelogs/fragments/429-add-cert-auth-variables.yml
+++ b/changelogs/fragments/429-add-cert-auth-variables.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - Add option to set the cert_auth_public_key and cert_auth_private_key parameters using the variables ansible_hashi_vault_cert_auth_public_key and ansible_hashi_vault_cert_auth_private_key (https://github.com/ansible-collections/community.hashi_vault/issues/428).
+  - cert auth - add option to set the ``cert_auth_public_key`` and ``cert_auth_private_key`` parameters using the variables ``ansible_hashi_vault_cert_auth_public_key`` and ``ansible_hashi_vault_cert_auth_private_key`` (https://github.com/ansible-collections/community.hashi_vault/issues/428).

--- a/changelogs/fragments/429-add-cert-auth-variables.yml
+++ b/changelogs/fragments/429-add-cert-auth-variables.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Add option to set the cert_auth_public_key and cert_auth_private_key parameters using the variables ansible_hashi_vault_cert_auth_public_key and ansible_hashi_vault_cert_auth_private_key (https://github.com/ansible-collections/community.hashi_vault/pull/429).

--- a/plugins/doc_fragments/auth.py
+++ b/plugins/doc_fragments/auth.py
@@ -298,6 +298,7 @@ class ModuleDocFragment(object):
           - name: ANSIBLE_HASHI_VAULT_CERT_AUTH_PUBLIC_KEY
         vars:
           - name: ansible_hashi_vault_cert_auth_public_key
+            version_added: 6.2.0
         ini:
           - section: hashi_vault_collection
             key: cert_auth_public_key
@@ -306,6 +307,7 @@ class ModuleDocFragment(object):
           - name: ANSIBLE_HASHI_VAULT_CERT_AUTH_PRIVATE_KEY
         vars:
           - name: ansible_hashi_vault_cert_auth_private_key
+            version_added: 6.2.0
         ini:
           - section: hashi_vault_collection
             key: cert_auth_private_key

--- a/plugins/doc_fragments/auth.py
+++ b/plugins/doc_fragments/auth.py
@@ -296,12 +296,16 @@ class ModuleDocFragment(object):
       cert_auth_public_key:
         env:
           - name: ANSIBLE_HASHI_VAULT_CERT_AUTH_PUBLIC_KEY
+        vars:
+          - name: ansible_hashi_vault_cert_auth_public_key
         ini:
           - section: hashi_vault_collection
             key: cert_auth_public_key
       cert_auth_private_key:
         env:
           - name: ANSIBLE_HASHI_VAULT_CERT_AUTH_PRIVATE_KEY
+        vars:
+          - name: ansible_hashi_vault_cert_auth_private_key
         ini:
           - section: hashi_vault_collection
             key: cert_auth_private_key


### PR DESCRIPTION
##### SUMMARY
This PR adds option to set the cert_auth_public_key and cert_auth_private_key parameters using the variables ansible_hashi_vault_cert_auth_public_key and ansible_hashi_vault_cert_auth_private_key.

Since AWX does not permit setting environment variables with the `ANSIBLE_` prefix, this will help to use those variables instead.

Resolves #428 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
hashi_vault lookup

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
      cert_auth_public_key:
        env:
          - name: ANSIBLE_HASHI_VAULT_CERT_AUTH_PUBLIC_KEY
        vars:
          - name: ansible_hashi_vault_cert_auth_public_key
        ini:
          - section: hashi_vault_collection
            key: cert_auth_public_key
      cert_auth_private_key:
        env:
          - name: ANSIBLE_HASHI_VAULT_CERT_AUTH_PRIVATE_KEY
        vars:
          - name: ansible_hashi_vault_cert_auth_private_key
        ini:
          - section: hashi_vault_collection
            key: cert_auth_private_key
```
