### PR TITLE
Added an auth method for GCP

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -105,7 +105,11 @@ flags:
   target_auth_token:
     paths:
       - plugins/module_utils/_auth_method_token.py
-
+  
+  target_auth_gcp:
+    paths:
+      - plugins/module_utils/_auth_method_gcp.py
+  
   target_auth_userpass:
     paths:
       - plugins/module_utils/_auth_method_userpass.py

--- a/plugins/doc_fragments/auth.py
+++ b/plugins/doc_fragments/auth.py
@@ -28,6 +28,7 @@ class ModuleDocFragment(object):
           - azure
           - jwt
           - cert
+          - gcp
           - none
         default: token
         type: str

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -145,6 +145,12 @@ EXAMPLES = """
   ansible.builtin.debug:
     msg: "{{ lookup('community.hashi_vault.hashi_vault', 'secret/hola:val', auth_method='jwt', role_id='myroleid', jwt='myjwt', url='https://vault:8200') }}"
 
+#GCP auth
+
+- name: Authenticate with GCP
+  ansible.builtin.debug:
+    msg: "{{ lookup('community.hashi_vault.hashi_vault', 'secret/hola:val', auth_method='gcp', role_id='myroleid', jwt='myjwt', url='https://vault:8200') }}"
+
 # Disabling Token Validation
 # Use this when your token does not have the lookup-self capability. Usually this is applied to all tokens via the default policy.
 # However you can choose to create tokens without applying the default policy, or you can modify your default policy not to include it.

--- a/plugins/module_utils/_auth_method_gcp.py
+++ b/plugins/module_utils/_auth_method_gcp.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024 Michael Woodham (woodham@google.com)
+# Simplified BSD License (see LICENSES/BSD-2-Clause.txt or https://opensource.org/licenses/BSD-2-Clause)
+# SPDX-License-Identifier: BSD-2-Clause
+
+'''Python versions supported: >=3.6'''
+
+# FOR INTERNAL COLLECTION USE ONLY
+# The interfaces in this file are meant for use within the community.hashi_vault collection
+# and may not remain stable to outside uses. Changes may be made in ANY release, even a bugfix release.
+# See also: https://github.com/ansible/community/issues/539#issuecomment-780839686
+# Please open an issue if you have questions about this.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible_collections.community.hashi_vault.plugins.module_utils._hashi_vault_common import HashiVaultAuthMethodBase
+
+
+class HashiVaultAuthMethodGcp(HashiVaultAuthMethodBase):
+    '''HashiVault option group class for auth: gcp'''
+
+    NAME = 'jwt'
+    OPTIONS = ['jwt', 'role_id', 'mount_point']
+
+    def __init__(self, option_adapter, warning_callback, deprecate_callback):
+        super(HashiVaultAuthMethodGcp, self).__init__(option_adapter, warning_callback, deprecate_callback)
+
+    def validate(self):
+        self.validate_by_required_fields('role_id', 'jwt')
+
+    def authenticate(self, client, use_token=True):
+        params = self._options.get_filled_options(*self.OPTIONS)
+        params['role'] = params.pop('role_id')
+
+        if 'mount_point' in params:
+            params['path'] = params.pop('mount_point')
+
+        try:
+            response = client.auth.gcp.login(**params)
+        except (NotImplementedError, AttributeError):
+            raise NotImplementedError("GCP authentication requires HVAC version 0.7.1 or higher.")
+
+        if use_token:
+            client.token = response['auth']['client_token']
+
+        return response

--- a/plugins/module_utils/_authenticator.py
+++ b/plugins/module_utils/_authenticator.py
@@ -24,6 +24,7 @@ from ansible_collections.community.hashi_vault.plugins.module_utils._auth_method
 from ansible_collections.community.hashi_vault.plugins.module_utils._auth_method_none import HashiVaultAuthMethodNone
 from ansible_collections.community.hashi_vault.plugins.module_utils._auth_method_token import HashiVaultAuthMethodToken
 from ansible_collections.community.hashi_vault.plugins.module_utils._auth_method_userpass import HashiVaultAuthMethodUserpass
+from ansible_collections.community.hashi_vault.plugins.module_utils._auth_method_gcp import HashiVaultAuthMethodGcp
 
 
 class HashiVaultAuthenticator():
@@ -37,6 +38,7 @@ class HashiVaultAuthenticator():
             'azure',
             'jwt',
             'cert',
+            'gcp',
             'none',
         ]),
         mount_point=dict(type='str'),
@@ -73,6 +75,7 @@ class HashiVaultAuthenticator():
             'azure': HashiVaultAuthMethodAzure(option_adapter, warning_callback, deprecate_callback),
             'cert': HashiVaultAuthMethodCert(option_adapter, warning_callback, deprecate_callback),
             'jwt': HashiVaultAuthMethodJwt(option_adapter, warning_callback, deprecate_callback),
+            'gcp': HashiVaultAuthMethodGcp(option_adapter, warning_callback, deprecate_callback),
             'ldap': HashiVaultAuthMethodLdap(option_adapter, warning_callback, deprecate_callback),
             'none': HashiVaultAuthMethodNone(option_adapter, warning_callback, deprecate_callback),
             'token': HashiVaultAuthMethodToken(option_adapter, warning_callback, deprecate_callback),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The following plugin adds gcp as an auth method. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
auth_method_gcp

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
fatal: [localhost]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'community.hashi_vault.hashi_vault'. Error was a <class 'ansible.errors.AnsibleOptionsError'>, original message: Invalid value \"gcp\" for configuration option \"plugin_type: lookup plugin: ansible_collections.community.hashi_vault.plugins.lookup.hashi_vault setting: auth_method \", valid values are: ['token', 'userpass', 'ldap', 'approle', 'aws_iam', 'azure', 'jwt', 'cert', 'none']"}
```

After:
```
[WARNING]: Collection <collection> does not support Ansible version 2.11.12
ok: [<collection>]

```
