### PR TITLE
Move parse_kev_term into the hashi_vault lookup #351

### DIFF
--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -253,6 +253,29 @@ except ImportError:
 
 
 class LookupModule(HashiVaultLookupBase):
+    def parse_kev_term(self, term, plugin_name, first_unqualified=None):
+        '''parses a term string into a dictionary'''
+        param_dict = {}
+
+        for i, param in enumerate(term.split()):
+            try:
+                key, value = param.split('=', 1)
+            except ValueError:
+                if i == 0 and first_unqualified is not None:
+                    # allow first item to be specified as value only and assign to assumed option name
+                    key = first_unqualified
+                    value = param
+                else:
+                    raise AnsibleError("%s lookup plugin needs key=value pairs, but received %s" % (plugin_name, term))
+
+            if key in param_dict:
+                msg = "Duplicate key '%s' in the term string '%s'." % (key, term)
+                raise AnsibleOptionsError(msg)
+
+            param_dict[key] = value
+
+        return param_dict
+    
     def run(self, terms, variables=None, **kwargs):
         if not HAS_HVAC:
             raise AnsibleError("Please pip install hvac to use the hashi_vault lookup module.")

--- a/plugins/plugin_utils/_hashi_vault_lookup_base.py
+++ b/plugins/plugin_utils/_hashi_vault_lookup_base.py
@@ -26,26 +26,3 @@ class HashiVaultLookupBase(HashiVaultPlugin, LookupBase):
     def __init__(self, loader=None, templar=None, **kwargs):
         HashiVaultPlugin.__init__(self)
         LookupBase.__init__(self, loader=loader, templar=templar, **kwargs)
-
-    def parse_kev_term(self, term, plugin_name, first_unqualified=None):
-        '''parses a term string into a dictionary'''
-        param_dict = {}
-
-        for i, param in enumerate(term.split()):
-            try:
-                key, value = param.split('=', 1)
-            except ValueError:
-                if i == 0 and first_unqualified is not None:
-                    # allow first item to be specified as value only and assign to assumed option name
-                    key = first_unqualified
-                    value = param
-                else:
-                    raise AnsibleError("%s lookup plugin needs key=value pairs, but received %s" % (plugin_name, term))
-
-            if key in param_dict:
-                msg = "Duplicate key '%s' in the term string '%s'." % (key, term)
-                raise AnsibleOptionsError(msg)
-
-            param_dict[key] = value
-
-        return param_dict


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Move parse_kev_term into the hashi_vault lookup

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

parse_kev_term is used to parse key=value pairs from a term string for filling in options. It's only used in the hashi_vault lookup, but it currently exists in our lookup base class, and it really doesn't need to be there.

Since we plan to not support this method of supplying options in any other plugins, it is moved up into the one lookup where it's used.

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

The parse_kev_term here
https://github.com/ansible-collections/community.hashi_vault/blob/main/plugins/plugin_utils/_hashi_vault_lookup_base.py#L30-L47

is deleted from that class and moved to LookupModule class in hashi_vault.py in lookup folder 

<!--- Paste verbatim command output below, e.g. before and after your change -->

The parse_kev_term is just shifted from one class to other, thus there is no change in output.