### PR TITLE
Upgrade antsibull-docs to 2.x.y

### DIFF
--- a/docs/preview/requirements.txt
+++ b/docs/preview/requirements.txt
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-antsibull-docs >= 1.0.0, < 2.0.0
+antsibull-docs >= 2.0.0, < 3.0.0
 ansible-pygments
 sphinx != 5.2.0.post0  # temporary, see https://github.com/ansible-community/antsibull-docs/issues/39, https://github.com/ansible-community/antsibull-docs/issues/40
 sphinx-ansible-theme >= 0.9.0


### PR DESCRIPTION
##### SUMMARY
1.x.y seems to be causing trouble in CI (https://github.com/ansible-collections/community.hashi_vault/actions/runs/11022260867/job/30611178243).

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs build
