### PR TITLE
disable surge docs push

### DIFF
--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -33,19 +33,19 @@ jobs:
       # with the committed init-dest-dir, hence the validate-docs job, which will
       # prevent publish from running in the case of failures.
 
-  publish-docs-surge:
-    # for now we won't run this on forks
-    if: github.repository == 'ansible-collections/community.hashi_vault'
-    permissions:
-      contents: read
-    needs: [validate-docs, build-docs]
-    name: Publish Ansible Docs
-    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-publish-surge.yml@main
-    with:
-      artifact-name: ${{ needs.build-docs.outputs.artifact-name }}
-      surge-site-name: community-hashi-vault-main.surge.sh
-    secrets:
-      SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+  # publish-docs-surge:
+  #   # for now we won't run this on forks
+  #   if: github.repository == 'ansible-collections/community.hashi_vault'
+  #   permissions:
+  #     contents: read
+  #   needs: [validate-docs, build-docs]
+  #   name: Publish Ansible Docs
+  #   uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-publish-surge.yml@main
+  #   with:
+  #     artifact-name: ${{ needs.build-docs.outputs.artifact-name }}
+  #     surge-site-name: community-hashi-vault-main.surge.sh
+  #   secrets:
+  #     SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
 
   publish-docs-gh-pages:
     # for now we won't run this on forks

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,20 +40,20 @@ jobs:
       init-dest-dir: docs/preview
       render-file-line: '> * `$<status>` [$<path_tail>](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr/${{ github.event.number }}/$<path_tail>)'
 
-  publish-docs-surge:
-    # for now we won't run this on forks
-    if: github.repository == 'ansible-collections/community.hashi_vault'
-    permissions:
-      contents: read
-    needs: [build-docs]
-    name: Publish Ansible Docs
-    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-publish-surge.yml@main
-    with:
-      artifact-name: ${{ needs.build-docs.outputs.artifact-name }}
-      surge-site-name: community-hashi-vault-pr${{ github.event.number }}.surge.sh
-      action: ${{ (github.event.action == 'closed' || needs.build-docs.outputs.changed != 'true') && 'teardown' || 'publish' }}
-    secrets:
-      SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+  # publish-docs-surge:
+  #   # for now we won't run this on forks
+  #   if: github.repository == 'ansible-collections/community.hashi_vault'
+  #   permissions:
+  #     contents: read
+  #   needs: [build-docs]
+  #   name: Publish Ansible Docs
+  #   uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-publish-surge.yml@main
+  #   with:
+  #     artifact-name: ${{ needs.build-docs.outputs.artifact-name }}
+  #     surge-site-name: community-hashi-vault-pr${{ github.event.number }}.surge.sh
+  #     action: ${{ (github.event.action == 'closed' || needs.build-docs.outputs.changed != 'true') && 'teardown' || 'publish' }}
+  #   secrets:
+  #     SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
 
   publish-docs-gh-pages:
     # for now we won't run this on forks


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Surge docs push is failing with invalid token. We've only been linking to the GH pages version of the docsite for years now anyway and I don't want to figure out what's wrong with surge.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- CI Pull Request
