### PR TITLE
CI: switch to non-deprecated singular form

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -21,7 +21,7 @@ env:
   NAMESPACE: community
   COLLECTION_NAME: hashi_vault
   ANSIBLE_FORCE_COLOR: true
-  ANSIBLE_COLLECTIONS_PATHS: ${{ github.workspace }}
+  ANSIBLE_COLLECTIONS_PATH: ${{ github.workspace }}
 
 jobs:
 


### PR DESCRIPTION
##### SUMMARY
The plural form has been removed from ansible-core devel. The singluar form has been present since ansible-base 2.10.

Ref: https://forum.ansible.com/t/couldnt-resolve-module-action-community-crypto-openssl-privatekey-only-with-ansible-core-devel/10711/2

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
GHA CI
