### PR TITLE
fix codecov uploader CLI location

### DIFF
--- a/.github/actions/ansible-codecov/action.yml
+++ b/.github/actions/ansible-codecov/action.yml
@@ -56,9 +56,9 @@ runs:
             ./codecov --version
         else
             curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --import # One-time step
-            curl -Os https://uploader.codecov.io/${{ inputs.codecov-uploader-version }}/linux/codecov
-            curl -Os https://uploader.codecov.io/${{ inputs.codecov-uploader-version }}/linux/codecov.SHA256SUM
-            curl -Os https://uploader.codecov.io/${{ inputs.codecov-uploader-version }}/linux/codecov.SHA256SUM.sig
+            curl -Os https://cli.codecov.io/linux/${{ inputs.codecov-uploader-version }}/codecov
+            curl -Os https://cli.codecov.io/linux/${{ inputs.codecov-uploader-version }}/codecov.SHA256SUM
+            curl -Os https://cli.codecov.io/linux/${{ inputs.codecov-uploader-version }}/codecov.SHA256SUM.sig
             gpg --verify codecov.SHA256SUM.sig codecov.SHA256SUM
             shasum -a 256 -c codecov.SHA256SUM
             chmod +x codecov


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
At some point codecov changed their uploader location binaries. They left the old ones in place but stopped updating them, so the custom action has been downloading "latest" from the old location.

This repo has been plagued with hours long "tokenless" uploads to codecov. They have apparently improved this but it requires CLI version 9 or higher and we were stuck on 8 due to downloading from the wrong location:
- https://docs.codecov.com/docs/codecov-tokens#uploading-without-a-token

Hopefully this will fix that.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- CI Pull Request
