### PR TITLE
bump sanity python to 3.13

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           # it is just required to run that once as "ansible-test sanity" in the docker image
           # will run on all python versions it supports.
-          python-version: '3.11'
+          python-version: '3.13'
 
       # Install the head of the given branch (devel, stable-2.14)
       - name: Install ansible-core (${{ matrix.ansible }})


### PR DESCRIPTION
##### SUMMARY
Bump sanity test python to 3.13. This should have been done in #471 but was missed. This doesn't affect supported versions since it's just the python used to run `ansible-test`.

Since devel's minimum has changed to 3.12, CI is currently failing since it's using 3.11.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- CI Pull Request
