### PR TITLE
Address sanity test failures and docs for `keys` return fields

### DIFF
--- a/changelogs/fragments/488-db-keys-returns.yml
+++ b/changelogs/fragments/488-db-keys-returns.yml
@@ -1,0 +1,8 @@
+---
+trivial:
+  - database modules - ignored new sanity test since it has no provision for describing the natural keys returned by an upstream API (https://github.com/ansible-collections/community.hashi_vault/pull/488).
+
+bugfixes:
+  - vault_database_connections_list module - tweaked documentation about the ``keys`` field returned from the API (https://github.com/ansible-collections/community.hashi_vault/pull/488).
+  - vault_database_roles_list module - tweaked documentation about the ``keys`` field returned from the API (https://github.com/ansible-collections/community.hashi_vault/pull/488).
+  - vault_database_static_roles_list module - tweaked documentation about the ``keys`` field returned from the API (https://github.com/ansible-collections/community.hashi_vault/pull/488).

--- a/plugins/modules/vault_database_connections_list.py
+++ b/plugins/modules/vault_database_connections_list.py
@@ -73,7 +73,7 @@ data:
   sample:
     keys: *sample_connections
 connections:
-  description: The list of database connections or en empty list. This can also be accessed via RV(data.keys) or RV(raw.data.keys).
+  description: The list of database connections or en empty list. This can also be accessed via RV(data['keys']) or RV(raw.data['keys']).
   returned: success
   type: list
   elements: str

--- a/plugins/modules/vault_database_roles_list.py
+++ b/plugins/modules/vault_database_roles_list.py
@@ -21,7 +21,7 @@ description:
   - Returns a list of available (dynamic) roles.
 notes:
   - This API returns a member named C(keys).
-  - In Ansible, accessing RV(data.keys) or RV(raw.data.keys) will not work because the dict object contains a method named C(keys).
+  - In Ansible, accessing RV(data['keys']) or RV(raw.data['keys']) will not work because the dict object contains a method named C(keys).
   - Instead, use RV(roles) to access the list of roles, or use the syntax C(data["keys"]) or C(raw.data["keys"]) to access the list via dict member.
 extends_documentation_fragment:
   - community.hashi_vault.attributes
@@ -74,7 +74,7 @@ data:
   sample:
     keys: *sample_roles
 roles:
-  description: The list of dynamic roles or en empty list. This can also be accessed via RV(data.keys) or RV(raw.data.keys).
+  description: The list of dynamic roles or en empty list. This can also be accessed via RV(data['keys']) or RV(raw.data['keys']).
   returned: success
   type: list
   elements: str

--- a/plugins/modules/vault_database_static_roles_list.py
+++ b/plugins/modules/vault_database_static_roles_list.py
@@ -74,7 +74,7 @@ data:
   sample:
     keys: *sample_roles
 roles:
-  description: The list of roles or en empty list. This can also be accessed via RV(data.keys) or RV(raw.data.keys).
+  description: The list of roles or en empty list. This can also be accessed via RV(data['keys']) or RV(raw.data['keys']).
   returned: success
   type: list
   elements: str

--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -1,0 +1,4 @@
+plugins/modules/vault_database_connections_list.py validate-modules:bad-return-value-key
+plugins/modules/vault_database_static_roles_list.py validate-modules:bad-return-value-key
+plugins/modules/vault_database_roles_list.py validate-modules:bad-return-value-key
+plugins/modules/vault_database_static_roles_list.py validate-modules:bad-return-value-key

--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -1,4 +1,3 @@
 plugins/modules/vault_database_connections_list.py validate-modules:bad-return-value-key
-plugins/modules/vault_database_static_roles_list.py validate-modules:bad-return-value-key
 plugins/modules/vault_database_roles_list.py validate-modules:bad-return-value-key
 plugins/modules/vault_database_static_roles_list.py validate-modules:bad-return-value-key

--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -1,3 +1,3 @@
-plugins/modules/vault_database_connections_list.py validate-modules:bad-return-value-key
-plugins/modules/vault_database_roles_list.py validate-modules:bad-return-value-key
-plugins/modules/vault_database_static_roles_list.py validate-modules:bad-return-value-key
+plugins/modules/vault_database_connections_list.py validate-modules:bad-return-value-key  # https://github.com/ansible-collections/community.hashi_vault/pull/488
+plugins/modules/vault_database_roles_list.py validate-modules:bad-return-value-key  # https://github.com/ansible-collections/community.hashi_vault/pull/488
+plugins/modules/vault_database_static_roles_list.py validate-modules:bad-return-value-key  # https://github.com/ansible-collections/community.hashi_vault/pull/488


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
See:
- https://github.com/ansible/ansible/pull/86079

Some of the database APIs return a sub-key named `keys` which is one of the values that's inaccessible via jinja2 dot `.` notation due to it to being a method on the underlying `dict` object in python.

A new sanity test now fails when these values are defined in return values, even if they are only describing a field that is returned from upstream. There is no way to tell the test that these are intentional or incidental (while others may not be), so as I see it the options were:
- Remove the description from return values (which makes the documentation less useful)
- Add these to sanity ignores forever

I chose the latter even though it's more annoying to maintain. We don't have control over what Vault returns and it's probably better to document the values that are relevant.

We already had notes in the docs explaining how to access `keys` correctly.

We're already "aliasing" these values in the module for convenience purposes, like providing a `roles` return value that is the same as `data.keys` and recommending its use, so we're already providing a more straightforward way to access the data being asked for, but it  makes sense to not only return the full data structures but describe them accurately so that when people compare to the CLI or the HTTP API they can clearly map these values.

The one other change I've made here is to change markup return values from like `RV(raw.data.keys)` to `RV(raw.data['keys'])`. This renders as written, but technically does not link to the right place, since it will link to the "parent" value in the HTML.

I think this is better since the anchors have limited use in our docs where they pretty much all fit within view.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Documentation Pull Request

