### PR TITLE
feat Support for request headers

### DIFF
--- a/plugins/doc_fragments/connection.py
+++ b/plugins/doc_fragments/connection.py
@@ -76,6 +76,13 @@ class ModuleDocFragment(object):
           - warn
         default: warn
         version_added: 1.3.0
+      headers:
+        description:
+          - Custom HTTP headers to include in every request to Vault.
+          - Useful for passing authentication headers for proxies or services in front of Vault, such as Cloudflare Access.
+          - 'Example: C({"CF-Access-Client-Id": "your-client-id", "CF-Access-Client-Secret": "your-client-secret"})'
+        type: dict
+        version_added: 6.3.0
     '''
 
     PLUGINS = r'''
@@ -158,4 +165,12 @@ class ModuleDocFragment(object):
               version_added: 1.4.0
           vars:
             - name: ansible_hashi_vault_retry_action
+        headers:
+          env:
+            - name: ANSIBLE_HASHI_VAULT_HEADERS
+          ini:
+            - section: hashi_vault_collection
+              key: headers
+          vars:
+            - name: ansible_hashi_vault_headers
       '''

--- a/plugins/module_utils/_connection_options.py
+++ b/plugins/module_utils/_connection_options.py
@@ -51,7 +51,7 @@ except ImportError:
 class HashiVaultConnectionOptions(HashiVaultOptionGroupBase):
     '''HashiVault option group class for connection options'''
 
-    OPTIONS = ['url', 'proxies', 'ca_cert', 'validate_certs', 'namespace', 'timeout', 'retries', 'retry_action']
+    OPTIONS = ['url', 'proxies', 'ca_cert', 'validate_certs', 'namespace', 'timeout', 'retries', 'retry_action', 'headers']
 
     ARGSPEC = dict(
         url=dict(type='str', default=None),
@@ -62,6 +62,7 @@ class HashiVaultConnectionOptions(HashiVaultOptionGroupBase):
         timeout=dict(type='int'),
         retries=dict(type='raw'),
         retry_action=dict(type='str', choices=['ignore', 'warn'], default='warn'),
+        headers=dict(type='dict', default=None),
     )
 
     _LATE_BINDING_ENV_VAR_OPTIONS = {
@@ -99,17 +100,27 @@ class HashiVaultConnectionOptions(HashiVaultOptionGroupBase):
         '''returns kwargs to be used for constructing an hvac.Client'''
 
         # validate_certs is only used to optionally change the value of ca_cert
+        # headers is handled specially via session
         def _filter(k, v):
-            return v is not None and k not in ('validate_certs', 'ca_cert')
+            return v is not None and k not in ('validate_certs', 'ca_cert', 'headers')
 
         # our transformed ca_cert value will become the verify parameter for the hvac client
         hvopts = self._options.get_filtered_options(_filter, *self.OPTIONS)
         hvopts['verify'] = self._conopt_verify
 
         retry_action = hvopts.pop('retry_action')
+        headers = self._options.get_option('headers')
+
         if 'retries' in hvopts:
             hvopts['session'] = self._get_custom_requests_session(new_callback=self._retry_callback_generator(retry_action), **hvopts.pop('retries'))
             hvopts['session'].verify = self._conopt_verify
+            if headers:
+                hvopts['session'].headers.update(headers)
+        elif headers:
+            # create a session just for custom headers (no retries configured)
+            sess = Session()
+            sess.headers.update(headers)
+            hvopts['session'] = sess
 
         return hvopts
 

--- a/tests/unit/plugins/module_utils/test_hashi_vault_connection_options.py
+++ b/tests/unit/plugins/module_utils/test_hashi_vault_connection_options.py
@@ -31,6 +31,7 @@ CONNECTION_OPTIONS = {
     'timeout': None,
     'retries': None,
     'retry_action': 'warn',
+    'headers': None,
 }
 
 
@@ -270,3 +271,57 @@ class TestHashiVaultConnectionOptions(object):
 
         with pytest.raises(HashiVaultValueError, match=r'Required option url was not set'):
             connection_options.process_connection_options()
+
+    # headers tests
+    # headers can be specified as a dictionary of custom HTTP headers
+    # to include in every request to Vault
+
+    @pytest.mark.parametrize('opt_headers', [
+        None,
+        {'X-Custom-Header': 'custom-value'},
+        {'CF-Access-Client-Id': 'client-id', 'CF-Access-Client-Secret': 'client-secret'},
+    ])
+    def test_get_hvac_connection_options_headers_only(self, connection_options, adapter, opt_headers):
+        """Test that headers create a session when no retries are configured"""
+        adapter.set_option('headers', opt_headers)
+
+        connection_options.process_connection_options()
+        opts = connection_options.get_hvac_connection_options()
+
+        # headers should not appear directly in opts
+        assert 'headers' not in opts
+
+        if opt_headers:
+            # session should be created for headers
+            assert 'session' in opts
+            assert isinstance(opts['session'], Session)
+            # verify headers are set on the session
+            for key, value in opt_headers.items():
+                assert opts['session'].headers.get(key) == value
+        else:
+            # no session created when no headers and no retries
+            assert 'session' not in opts
+
+    @pytest.mark.parametrize('opt_headers', [
+        {'X-Custom-Header': 'custom-value'},
+        {'CF-Access-Client-Id': 'client-id', 'CF-Access-Client-Secret': 'client-secret'},
+    ])
+    @pytest.mark.parametrize('opt_retries', [2, {'total': 3}])
+    def test_get_hvac_connection_options_headers_with_retries(self, connection_options, adapter, opt_headers, opt_retries):
+        """Test that headers are added to session when retries are also configured"""
+        adapter.set_option('headers', opt_headers)
+        adapter.set_option('retries', opt_retries)
+
+        connection_options.process_connection_options()
+        opts = connection_options.get_hvac_connection_options()
+
+        # headers should not appear directly in opts
+        assert 'headers' not in opts
+
+        # session should be created (from retries)
+        assert 'session' in opts
+        assert isinstance(opts['session'], Session)
+
+        # verify headers are set on the session
+        for key, value in opt_headers.items():
+            assert opts['session'].headers.get(key) == value


### PR DESCRIPTION
##### SUMMARY
Adds support for passing headers with the connection session. My use-case is to provide Cloudflare Zero-Trust access tokens to punch through CF ZT auth to reach our Vault server. This PR works, we are using it to build our new Ansible codebase.

##### ISSUE TYPE
- Feature Pull Request: https://github.com/ansible-collections/community.hashi_vault/issues/494

##### COMPONENT NAME
`plugins/module_utils/_connection_options.py`
